### PR TITLE
Fixed env instructions for Self-hosted Remote Storage

### DIFF
--- a/docs/content/docs/1.getting-started/3.deploy.md
+++ b/docs/content/docs/1.getting-started/3.deploy.md
@@ -81,11 +81,11 @@ Once the deployment is done, NuxtHub should be ready to use in your deployed pro
 
 To enable remote storage in your self-hosted project, you need to create a secret key.
 
-1. Set the `NUXT_HUB_PROJECT_SECRET` environment variable in your Cloudflare Pages project settings and retry the last deployment to apply the changes (you can generate a random secret on https://www.uuidgenerator.net/version4)
-2. Set the same `NUXT_HUB_PROJECT_SECRET` and `NUXT_HUB_PROJECT_URL` environment variables in your local project
+1. Set the `NUXT_HUB_PROJECT_SECRET_KEY` environment variable in your Cloudflare Pages project settings and retry the last deployment to apply the changes (you can generate a random secret on https://www.uuidgenerator.net/version4)
+2. Set the same `NUXT_HUB_PROJECT_SECRET_KEY` and `NUXT_HUB_PROJECT_URL` environment variables in your local project
 
 ```bash [.env]
-NUXT_HUB_PROJECT_SECRET=my-project-secret-used-in-cloudflare-env
+NUXT_HUB_PROJECT_SECRET_KEY=my-project-secret-used-in-cloudflare-env
 NUXT_HUB_PROJECT_URL=https://my-nuxthub-project.pages.dev
 ```
 


### PR DESCRIPTION
The getting started docs for Self-hosted Remote Storage instructs you to setup an environment variable named `NUXT_HUB_PROJECT_SECRET`. This, however, is incorrect. According to https://github.com/nuxt-hub/core/blob/main/src/module/index.ts it should be `NUXT_HUB_PROJECT_SECRET_KEY`.