### PR TITLE
fix: correct capitalisation for Cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License][license-src]][license-href]
 [![Nuxt][nuxt-src]][nuxt-href]
 
-Build full-stack applications with Nuxt on CloudFlare, with zero configuration.
+Build full-stack applications with Nuxt on Cloudflare, with zero configuration.
 
 ## Features
 


### PR DESCRIPTION
This PR corrects the capitalisation of Cloudflare.

- https://blog.cloudflare.com/time-for-an-update
- https://developers.cloudflare.com/style-guide/grammar/parts-of-speech/capitalization/

I've noticed Cloud**F**lare mentioned in the GitHub descriptions too.
- https://github.com/nuxt-hub
- https://github.com/nuxt-hub/core

I apologise for taking up time with such a little PR.