### PR TITLE
fix: GitHub edit link for content in app.config.ts

### DIFF
--- a/docs/app.config.ts
+++ b/docs/app.config.ts
@@ -51,7 +51,7 @@ export default defineAppConfig({
     title: 'Table of Contents',
     bottom: {
       title: 'Community',
-      edit: 'https://github.com/nuxt-hub/core/edit/main/content',
+      edit: 'https://github.com/nuxt-hub/core/edit/main/docs/content',
       links: [{
         icon: 'i-heroicons-star',
         label: 'Star on GitHub',


### PR DESCRIPTION
The current config [base link](https://github.com/nuxt-hub/core/edit/main/content) points to `https://github.com/nuxt-hub/core/edit/main/content`, but the [correct base link](https://github.com/nuxt-hub/core/edit/main/docs/content) is `https://github.com/nuxt-hub/core/edit/main/docs/content`