### PR TITLE
Fix D1_ERROR: A prepared SQL statement must contain only one statement.

### DIFF
--- a/docs/content/docs/3.recipes/2.drizzle.md
+++ b/docs/content/docs/3.recipes/2.drizzle.md
@@ -116,6 +116,7 @@ export default defineNitroPlugin(async () => {
       const statements = migration.split('--> statement-breakpoint')
       for (let stmt of statements) {
         stmt = stmt
+          .trim()
           .replace('CREATE TABLE', 'CREATE TABLE IF NOT EXISTS')
           .replace('CREATE INDEX', 'CREATE INDEX IF NOT EXISTS')
           .replace('CREATE UNIQUE INDEX', 'CREATE UNIQUE INDEX IF NOT EXISTS')


### PR DESCRIPTION
I followed through the Drizzle recipe in the docs and it seemed like the database migration did not go through with the following error:

```
[nitro] [unhandledRejection] Error: D1_ERROR: A prepared SQL statement must contain only one statement.
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at <anonymous> (C:\Users\Atom\Documents\GitHub\careear\server\plugins\migrations.ts:24:1)
    at getBindingsProxy (C:\Users\Atom\Documents\GitHub\careear\node_modules\@nuxthub\core\src\module\runtime\bindings.dev.ts:57:1) {
  [cause]: Error: A prepared SQL statement must contain only one statement.
      at D1Database._sendOrThrow (cloudflare-internal:d1-api:67:24)
      at async D1PreparedStatement.run (cloudflare-internal:d1-api:172:29) {
    [cause]: undefined
  }
}

```
I'm not sure how this happened because it was perfectly fine until recently, likely due to a dependency version (?). However, the `trim()` method fixed the error so I propose a small change in the docs. WDYT?