### PR TITLE
fix: DevTools Database CORs error

### DIFF
--- a/src/runtime/server/api/_hub/database/query.options.ts
+++ b/src/runtime/server/api/_hub/database/query.options.ts
@@ -1,0 +1,8 @@
+import { eventHandler, sendNoContent } from 'h3'
+import { requireNuxtHubAuthorization } from '../../../utils/auth'
+
+export default eventHandler(async (event) => {
+  // only handles CORs for Nuxt DevTools
+  await requireNuxtHubAuthorization(event)
+  return sendNoContent(event)
+})


### PR DESCRIPTION
When accessing the Database via the DevTools it shows a CORs error. This is due to the fetch occurring from an external domain (https://admin.hub.nuxt.com).

Normally this would be handled but we are filtering the route for `post` which is bypassing the `options` request.

This does not seem to be an issue for the other devtool pages.

![image](https://github.com/nuxt-hub/core/assets/5326365/dd6e59be-d332-4726-b405-08744b322a61)
