### PR TITLE
fix: fallback to custom placeholder when openAPI is disabled

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -151,6 +151,11 @@ export default defineNuxtModule<ModuleOptions>({
       return
     }
 
+    // Fallback to custom placeholder when openAPI is disabled
+    nuxt.options.alias['#hub/openapi'] = nuxt.options.nitro?.experimental?.openAPI === true ?
+      '#internal/nitro/routes/openapi' :
+      resolve('./runtime/templates/openapi')
+
     // Register composables
     addServerImportsDir(resolve('./runtime/server/utils'))
 

--- a/src/runtime/server/api/_hub/openapi.get.ts
+++ b/src/runtime/server/api/_hub/openapi.get.ts
@@ -13,7 +13,7 @@ export default eventHandler(async (event) => {
     })
   }
 
-  const openapi = await import('#internal/nitro/routes/openapi')
+  const openapi = await import('#hub/openapi')
     .then((mod) => mod.default)
     .catch(() => undefined)
 

--- a/src/runtime/templates/openapi.ts
+++ b/src/runtime/templates/openapi.ts
@@ -1,0 +1,1 @@
+export default () => ({})


### PR DESCRIPTION
resolves nuxt-hub/core#69