### PR TITLE
docs: Add seed configuration for database population with Nitro Tasks

### DIFF
--- a/docs/content/docs/4.recipes/2.drizzle.md
+++ b/docs/content/docs/4.recipes/2.drizzle.md
@@ -153,11 +153,11 @@ Note that we are also exporting the `User` type, which is inferred from the `use
 We also export the `sql`, `eq`, `and`, and `or` functions from `drizzle-orm` to be used in our queries.
 ::
 
-### Add Seed Config with Nitro Tasks (Optional)
+### Seed the database (Optional)
 
 ::collapsible{name="instructions"}
 
-Optionally, you can add a seed configuration to populate your database with initial data. This uses [Nitro Tasks](https://nitro.unjs.io/guide/tasks), which is currently an experimental feature.
+Optionally, you can add a server task to populate your database with initial data. This uses [Nitro Tasks](https://nitro.unjs.io/guide/tasks), which is currently an experimental feature.
 
 1. Update your nuxt.config.js:
 
@@ -203,7 +203,7 @@ export default defineTask({
 })
 ```
 
-To run the seed task, start your dev server and open the dev tools. Go to _Tasks_ and you will see the `db:seed` task ready to run. This will add the seed data to your database and give you the first users to work with.
+To run the seed task, start your dev server and open the Nuxt Devtools. Go to _Tasks_ and you will see the `db:seed` task ready to run. This will add the seed data to your database and give you the first users to work with.
 
 ::
 

--- a/docs/content/docs/4.recipes/2.drizzle.md
+++ b/docs/content/docs/4.recipes/2.drizzle.md
@@ -153,6 +153,59 @@ Note that we are also exporting the `User` type, which is inferred from the `use
 We also export the `sql`, `eq`, `and`, and `or` functions from `drizzle-orm` to be used in our queries.
 ::
 
+### Add Seed Config with Nitro Tasks (Optional)
+
+::collapsible{name="instructions"}
+
+Optionally, you can add a seed configuration to populate your database with initial data. This uses [Nitro Tasks](https://nitro.unjs.io/guide/tasks), which is currently an experimental feature.
+
+1. Update your nuxt.config.js:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  nitro: {
+    experimental: {
+      tasks: true
+    }
+  }
+})
+```
+
+2. Create a new file containing the task:
+
+```ts [server/task/seed.ts]
+export default defineTask({
+  meta: {
+    name: "db:seed",
+    description: "Run database seed task",
+  },
+  async run() {
+    console.log("Running DB seed task...")
+    const seed = [
+      {
+        name: "John Doe",
+        email: "john@example.com",
+        password: "password123",
+        avatar: "https://example.com/avatar/john.png",
+        createdAt: Date.now(),
+      },
+      {
+        name: "Jane Doe",
+        email: "jane@example.com",
+        password: "password123",
+        avatar: "https://example.com/avatar/jane.png",
+        createdAt: Date.now(),
+      },
+    ]
+    await useDrizzle().insert(tables.users).values(users);
+    return { result: "success" }
+  }
+})
+```
+
+To run the seed task, start your dev server and open the dev tools. Go to _Tasks_ and you will see the `db:seed` task ready to run. This will add the seed data to your database and give you the first users to work with.
+
+::
 
 ## Usage
 


### PR DESCRIPTION
Add a section to let users know how to populate their database using Nitro Tasks.

It would be great if we had an extensible component, something like

```md
### Adding Seed Config with Nitro Tasks (optional)

::expandable{title="Click here to see details"}

Instructions...

::
```

Currently the seed config steps are quite long and not that useful for everyone, so it is a bit of a waste of space. I tried to create a component with `UAccordion` but was unsuccessful in getting it to work.

If you have a reference of somewhere with the same component I am happy to port it here or feel free to implement it yourself in this PR. Let me know what you think :)