### PR TITLE
feat: use etag in blob.serve

### DIFF
--- a/src/runtime/server/utils/blob.ts
+++ b/src/runtime/server/utils/blob.ts
@@ -319,6 +319,7 @@ export function hubBlob(): HubBlob {
 
       setHeader(event, 'Content-Type', object.httpMetadata?.contentType || getContentType(pathname))
       setHeader(event, 'Content-Length', object.size)
+      setHeader(event, 'etag', object.httpEtag)
 
       return object.body
     },


### PR DESCRIPTION
fix #142

Add etag when serving blob to save bandwidth and speed up loading.

The server sends the etag and the browser adds `if-not-match` when asking the blob.
