### PR TITLE
fix(blob): remove slugify

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@cloudflare/workers-types": "^4.20240605.0",
     "@nuxt/devtools-kit": "^1.3.3",
     "@nuxt/kit": "^3.11.2",
-    "@sindresorhus/slugify": "^2.2.1",
     "@uploadthing/mime-types": "^0.2.10",
     "citty": "^0.1.6",
     "confbox": "^0.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@nuxt/kit':
         specifier: ^3.11.2
         version: 3.11.2(rollup@4.14.0)
-      '@sindresorhus/slugify':
-        specifier: ^2.2.1
-        version: 2.2.1
       '@uploadthing/mime-types':
         specifier: ^0.2.10
         version: 0.2.10

--- a/src/runtime/server/utils/blob.ts
+++ b/src/runtime/server/utils/blob.ts
@@ -1,4 +1,4 @@
-import type { extensions } from '@uploadthing/mime-types'
+import type { MimeType } from '@uploadthing/mime-types'
 import type { R2Bucket, ReadableStream, R2MultipartUpload } from '@cloudflare/workers-types/experimental'
 import { ofetch } from 'ofetch'
 import mime from 'mime'
@@ -746,7 +746,7 @@ function mapR2MpuToBlobMpu(mpu: R2MultipartUpload): BlobMultipartUpload {
 type PowOf2 = 1 | 2 | 4 | 8 | 16 | 32 | 64 | 128 | 256 | 512 | 1024
 type SizeUnit = 'B' | 'KB' | 'MB' | 'GB'
 type BlobSize = `${PowOf2}${SizeUnit}`
-type BlobType = 'image' | 'video' | 'audio' | 'pdf' | 'text' | 'blob' | keyof typeof extensions
+type BlobType = 'image' | 'video' | 'audio' | 'pdf' | 'text' | 'blob' | MimeType
 const FILESIZE_UNITS = ['B', 'KB', 'MB', 'GB']
 type FileSizeUnit = (typeof FILESIZE_UNITS)[number]
 

--- a/src/runtime/server/utils/blob.ts
+++ b/src/runtime/server/utils/blob.ts
@@ -1,5 +1,4 @@
 import type { extensions } from '@uploadthing/mime-types'
-import slugify from '@sindresorhus/slugify'
 import type { R2Bucket, ReadableStream, R2MultipartUpload } from '@cloudflare/workers-types/experimental'
 import { ofetch } from 'ofetch'
 import mime from 'mime'
@@ -334,9 +333,9 @@ export function hubBlob(): HubBlob {
 
       const { dir, ext, name: filename } = parse(pathname)
       if (addRandomSuffix) {
-        pathname = joinURL(dir === '.' ? '' : dir, `${slugify(filename)}-${randomUUID().split('-')[0]}${ext}`)
+        pathname = joinURL(dir === '.' ? '' : dir, `${filename}-${randomUUID().split('-')[0]}${ext}`)
       } else {
-        pathname = joinURL(dir === '.' ? '' : dir, `${slugify(filename)}${ext}`)
+        pathname = joinURL(dir === '.' ? '' : dir, `${filename}${ext}`)
       }
 
       if (prefix) {
@@ -375,9 +374,9 @@ export function hubBlob(): HubBlob {
 
       const { dir, ext, name: filename } = parse(pathname)
       if (addRandomSuffix) {
-        pathname = joinURL(dir === '.' ? '' : dir, `${slugify(filename)}-${randomUUID().split('-')[0]}${ext}`)
+        pathname = joinURL(dir === '.' ? '' : dir, `${filename}-${randomUUID().split('-')[0]}${ext}`)
       } else {
-        pathname = joinURL(dir === '.' ? '' : dir, `${slugify(filename)}${ext}`)
+        pathname = joinURL(dir === '.' ? '' : dir, `${filename}${ext}`)
       }
       if (prefix) {
         pathname = joinURL(prefix, pathname).replace(/\/+/g, '/').replace(/^\/+/, '')


### PR DESCRIPTION
Converting filename to a slug format is not necessary for uploading files to Cloudflare R2