### PR TITLE
docs: use nuxthub discord invite

### DIFF
--- a/docs/utils/index.ts
+++ b/docs/utils/index.ts
@@ -20,7 +20,7 @@ export const asideLinks = [
   }, {
     icon: 'i-ph-chat-centered-text-duotone',
     label: 'Chat on Discord',
-    to: 'https://discord.com/invite/nuxt',
+    to: 'https://discord.gg/e25qqXb2mF',
     target: '_blank'
   }, {
     icon: 'i-simple-icons-nuxtdotjs',


### PR DESCRIPTION
The sidebar on the docs invites to the regular Nuxt Discord rather than the NuxtHub one.

I've used the same public invite link shown on the pricing docs (docs/content/3.pricing.yml). NuxtHub admin dash -> feedback uses a different invite to the same server.