### PR TITLE
docs: missing pnpm version on github actions template

### DIFF
--- a/docs/content/1.docs/1.getting-started/3.deploy.md
+++ b/docs/content/1.docs/1.getting-started/3.deploy.md
@@ -71,6 +71,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
+          version: 9
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/docs/content/1.docs/1.getting-started/3.deploy.md
+++ b/docs/content/1.docs/1.getting-started/3.deploy.md
@@ -71,7 +71,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9
+          version: 8
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/docs/content/1.docs/1.getting-started/3.deploy.md
+++ b/docs/content/1.docs/1.getting-started/3.deploy.md
@@ -71,7 +71,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 8
+          version: 9
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
On the github actions workflow, the pnpm action is not providing the pnpm version which make the build failing.

