### PR TITLE
chore: uncomment pkg.pr.new 

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -23,8 +23,8 @@ jobs:
       - name: prepare
         run: pnpm dev:prepare
 
-      # - name: Release PR version
-      #   run: pnpm dlx pkg-pr-new@0.0 publish
+      - name: Release PR version
+        run: pnpm dlx pkg-pr-new@0.0 publish
 
       - name: Lint (code)
         run: pnpm lint --fix


### PR DESCRIPTION
Hey team, a while ago I published a fix for the issue nuxt-hub/core had with pkg.pr.new. 

And I wonder if there's anything I can do to get it back, would love to hear your thoughts. 