### PR TITLE
chore: disable prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
   "eslint.experimental.useFlatConfig": true,
+  "prettier.enable": false,
 }


### PR DESCRIPTION
Hello 👋,

Since eslint is enabled and used to format the code, I think it's a good idea to disable the vscode prettier extension to avoid conflicts between the two formatters.
