### PR TITLE
docs(drizzle): update remote option for running migrations

### DIFF
--- a/docs/content/1.docs/3.recipes/2.drizzle.md
+++ b/docs/content/1.docs/3.recipes/2.drizzle.md
@@ -117,7 +117,7 @@ export default defineNitroPlugin(async () => {
 Drizzle will create a `__drizzle_migrations` table in your database to keep track of the applied migrations. It will also run the migrations automatically in development mode.
 ::
 
-To apply the migrations in staging or production, you can run the server using `npx nuxi dev --remote` command to connect your local server to the remote database, learn more about [remote storage](/docs/getting-started/remote-storage).
+To apply the migrations in preview or production, you can run the server using `npx nuxi dev --remote` (for preview) or `npx nuxi dev --remote=production` (for production) command to connect your local server to the remote database, learn more about [remote storage](/docs/getting-started/remote-storage).
 
 ::note
 We are planning to update this section to leverage [Nitro Tasks](https://nitro.unjs.io/guide/tasks) instead of a server plugin in the future.


### PR DESCRIPTION
`--remote` option seems to default to `preview` since the last updates and `production` environment has to explicit now.