### PR TITLE
chore: use nitro compatibility flags by default

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -65,7 +65,9 @@ export default defineNuxtModule<ModuleOptions>({
       openapi: nuxt.options.nitro.experimental?.openAPI === true,
       // Extra bindings for the project
       bindings: {
-        hyperdrive: {}
+        hyperdrive: {},
+        // @ts-expect-error nitro.cloudflare.wrangler is not yet typed
+        compatibilityFlags: nuxt.options.nitro.cloudflare?.wrangler?.compatibility_flags
       }
     })
     runtimeConfig.hub = hub

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -99,7 +99,7 @@ export interface ModuleOptions {
     compatibilityDate?: string
     /**
      * Extra compatibility flags for the project.
-     * Note that NuxtHub will always add the 'nodejs_compat' flag if not specified.
+     * Note that NuxtHub will default to the Nitro compatibility flags for Cloudflare if not specified.
      * @see https://developers.cloudflare.com/workers/configuration/compatibility-dates/#compatibility-flags
      */
     compatibilityFlags?: string[]


### PR DESCRIPTION
So we can give a seamless experience when upgrading to Nitro future versions.