### PR TITLE
docs: update `pg` note

### DIFF
--- a/docs/content/1.docs/3.recipes/5.postgres.md
+++ b/docs/content/1.docs/3.recipes/5.postgres.md
@@ -39,7 +39,7 @@ That's it, you can now use the `postgres` package to connect to your PostgreSQL 
 ::
 
 ::warning
-Please note that [`pg`](https://www.npmjs.com/package/pg) is not compatible at the moment.
+Please note that in order to use [`pg`](https://www.npmjs.com/package/pg) a minimum version of `8.13.0` is required, alongside wrangler `3.78.7` or later and `compatibility_date = "2024-09-23"`.
 ::
 
 ## Usage


### PR DESCRIPTION
Updating docs based on a reply from @RihanArfan on discord, pointing out that [Cloudflare does support `pg` now](https://developers.cloudflare.com/hyperdrive/configuration/connect-to-postgres/#supported-drivers).