### PR TITLE
feat(blob): expose more data

### DIFF
--- a/docs/content/1.docs/2.features/blob.md
+++ b/docs/content/1.docs/2.features/blob.md
@@ -754,8 +754,10 @@ interface BlobObject {
   pathname: string
   contentType: string | undefined
   size: number
-  uploadedAt: Date,
-  customMetadata?: Record<string, string> | undefined
+  httpEtag: string
+  uploadedAt: Date
+  httpMetadata: Record<string, string>
+  customMetadata: Record<string, string>
 }
 ```
 

--- a/src/runtime/blob/server/utils/blob.ts
+++ b/src/runtime/blob/server/utils/blob.ts
@@ -638,7 +638,9 @@ function mapR2ObjectToBlob(object: R2Object): BlobObject {
     pathname: object.key,
     contentType: object.httpMetadata?.contentType,
     size: object.size,
+    httpEtag: object.httpEtag,
     uploadedAt: object.uploaded,
+    httpMetadata: object.httpMetadata || {},
     customMetadata: object.customMetadata || {}
   }
 }

--- a/src/types/blob.ts
+++ b/src/types/blob.ts
@@ -1,4 +1,4 @@
-import type { ReadableStream } from '@cloudflare/workers-types/experimental'
+import type { ReadableStream, R2HTTPMetadata } from '@cloudflare/workers-types/experimental'
 import type { MimeType } from '@uploadthing/mime-types'
 
 // Credits from shared utils of https://github.com/pingdotgg/uploadthing
@@ -22,13 +22,21 @@ export interface BlobObject {
    */
   size: number
   /**
+   * The blob's etag, in quotes so as to be returned as a header.
+   */
+  httpEtag: string
+  /**
    * The date the blob was uploaded at.
    */
   uploadedAt: Date
   /**
+   * The HTTP metadata of the blob.
+   */
+  httpMetadata: R2HTTPMetadata
+  /**
    * The custom metadata of the blob.
    */
-  customMetadata?: Record<string, string>
+  customMetadata: Record<string, string>
 }
 
 export interface BlobUploadedPart {


### PR DESCRIPTION
Expose `httpEtag` and `httpMetadata` from blob object.