### PR TITLE
fix: correctly resolve vectorize type

### DIFF
--- a/src/runtime/vectorize/server/utils/vectorize.ts
+++ b/src/runtime/vectorize/server/utils/vectorize.ts
@@ -3,7 +3,7 @@ import { joinURL } from 'ufo'
 import { createError } from 'h3'
 import type { H3Error } from 'h3'
 import type { RuntimeConfig } from 'nuxt/schema'
-import type { Vectorize } from '../../../../types/vectorize'
+import type { Vectorize } from '@nuxthub/core'
 import { requireNuxtHubFeature } from '../../../utils/features'
 import { useRuntimeConfig } from '#imports'
 


### PR DESCRIPTION
Closes #345

Correctly resolves the Vectorize type after build by importing it from from `@nuxthub/core`'s exported type. Behaviour matches D1 type for hubDatabase() now.