### PR TITLE
docs: typo index page

### DIFF
--- a/docs/content/0.index.yml
+++ b/docs/content/0.index.yml
@@ -3,7 +3,7 @@ navigation: false
 description: 'Deploy and scale your Nuxt applications worldwide with NuxtHub, the Cloudflare-powered platform that ensures lightning-fast performance at low cost and with full-stack capabilities.'
 hero:
   title: 'Ship Nuxt apps that scale.'
-  description: 'Deploy and scale your Nuxt applications worldwide with NuxtHub, the Cloudflare-powered platform that ensures lightning-fast performance at low cost and withfull-stack capabilities.'
+  description: 'Deploy and scale your Nuxt applications worldwide with NuxtHub, the Cloudflare-powered platform that ensures lightning-fast performance at low cost and with full-stack capabilities.'
   img:
     width: '1439'
     height: '681'


### PR DESCRIPTION
Typo on the [home page](https://hub.nuxt.com/)

![image](https://github.com/user-attachments/assets/a0c4fdbe-296d-44a4-b829-d44c289496e5)
