### PR TITLE
chore: remove deprecated D1 dump()

### DIFF
--- a/src/runtime/database/server/api/_hub/database/[command].post.ts
+++ b/src/runtime/database/server/api/_hub/database/[command].post.ts
@@ -15,16 +15,13 @@ export default eventHandler(async (event) => {
 
   // https://developers.cloudflare.com/d1/build-databases/query-databases/
   const { command } = await getValidatedRouterParams(event, z.object({
-    command: z.enum(['first', 'all', 'raw', 'run', 'dump', 'exec', 'batch'])
+    command: z.enum(['first', 'all', 'raw', 'run', 'exec', 'batch'])
   }).parse)
   const db = hubDatabase()
 
   if (command === 'exec') {
     const { query } = await readValidatedBody(event, statementValidation.pick({ query: true }).parse)
     return db.exec(query)
-  }
-  if (command === 'dump') {
-    return db.dump()
   }
   if (command === 'first') {
     const { query, params, colName } = await readValidatedBody(event, z.intersection(

--- a/src/runtime/database/server/utils/database.ts
+++ b/src/runtime/database/server/utils/database.ts
@@ -71,9 +71,6 @@ export function proxyHubDatabase(projectUrl: string, secretKey?: string, headers
         body: { query }
       }).catch(handleProxyError)
     },
-    async dump() {
-      return d1API<ArrayBuffer>('/dump').catch(handleProxyError)
-    },
     prepare(query: string) {
       const stmt = {
         _body: {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,3 +1,5 @@
 import type { D1Database as CFD1Database } from '@cloudflare/workers-types/experimental'
 
-export type D1Database = CFD1Database
+type OmitDump<T> = Omit<T, 'dump'>
+
+export type D1Database = OmitDump<CFD1Database>


### PR DESCRIPTION
Cloudflare D1 `db.dump()` is deprecated and only available to D1 alpha databases. https://developers.cloudflare.com/d1/build-with-d1/d1-client-api/#await-dbdump

As it wasn't documented on NuxtHub's docs, and that it wasn't usable either (as all databases should be newer than D1 Alpha), I believe this is not a breaking change.