### PR TITLE
fix(blob): handle `'pdf'` type correctly in `ensureBlob`

### DIFF
--- a/src/runtime/blob/server/utils/blob.ts
+++ b/src/runtime/blob/server/utils/blob.ts
@@ -717,7 +717,11 @@ export function ensureBlob(blob: Blob, options: BlobEnsureOptions = {}) {
     }
   }
   const blobShortType = blob.type.split('/')[0]
-  if (options.types?.length && !options.types.includes(blob.type as BlobType) && !options.types.includes(blobShortType as BlobType)) {
+  if (options.types?.length
+    && !options.types.includes(blob.type as BlobType)
+    && !options.types.includes(blobShortType as BlobType)
+    && !(options.types.includes('pdf' as BlobType) && blob.type === 'application/pdf')
+  ) {
     throw createError({
       statusCode: 400,
       message: `File type is invalid, must be: ${options.types.join(', ')}`


### PR DESCRIPTION
This PR fixes #391 

### For testing

1. Run dev server
2. Open `playground/server/api/blob/index.put.ts`
3. add ensure options to the `handleUpload` method
```ts
ensure: {
   types: ['pdf']
 },
```
4. Go to http://localhost:3000/blob
5. Try uploading a pdf file