### PR TITLE
docs(blob): proper input file type specifiers

### DIFF
--- a/docs/content/1.docs/2.features/blob.md
+++ b/docs/content/1.docs/2.features/blob.md
@@ -334,7 +334,7 @@ async function onFileSelect(event: Event) {
 </script>
 
 <template>
-  <input type="file" name="file" @change="onFileSelect" multiple accept="jpeg, png" />
+  <input type="file" name="file" @change="onFileSelect" multiple accept="image/jpeg, image/png" />
 </template>
 ```
 ::
@@ -691,7 +691,7 @@ async function onFileSelect({ target }: Event) {
 
 <template>
   <input
-    accept="jpeg, png"
+    accept="image/jpeg, image/png"
     type="file"
     name="file"
     multiple

--- a/playground/app/pages/blob.vue
+++ b/playground/app/pages/blob.vue
@@ -188,7 +188,6 @@ async function deleteFile(pathname: string) {
         <input
           ref="uploadRef"
           tabindex="-1"
-          accept="jpeg, png"
           type="file"
           name="files"
           multiple


### PR DESCRIPTION
Hello! 👋  This PR corrects the use of the input `accept` attribute in the documentation, as `accept="jpeg, png"` won't work as expected. [The proper format](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers) uses MIME types or file extensions starting with a period, so we could do `accept=".jpeg, .png"`  but I better suggest to use `accept="image/jpeg, image/png"` instead.

I also removed the `accept` attribute from the playground since we should be able to upload any file there