### PR TITLE
docs: improve postgres hyperdrive binding example

### DIFF
--- a/docs/content/1.docs/3.recipes/5.postgres.md
+++ b/docs/content/1.docs/3.recipes/5.postgres.md
@@ -117,7 +117,8 @@ import type { Hyperdrive } from '@cloudflare/workers-types'
 import postgres from 'postgres'
 
 export function usePostgres() {
-  const hyperdrive = process.env.POSTGRES as Hyperdrive | undefined
+  // @ts-expect-error globalThis.__env__ is not defined
+  const hyperdrive = process.env.POSTGRES || globalThis.__env__?.POSTGRES || globalThis.POSTGRES as Hyperdrive | undefined
   const dbUrl = hyperdrive?.connectionString || process.env.NUXT_POSTGRES_URL
   if (!dbUrl) {
     throw createError('Missing `POSTGRES` hyperdrive binding or `NUXT_POSTGRES_URL` env variable')


### PR DESCRIPTION
Made the hyperdrive binding example be the same as every other binding used in the module.
Only checking `process.env.POSTGRES` returns `null` in my project.
The new example works perfectly