### PR TITLE
fix(vectorize): return `undefined` instead of throwing in dev with no remote

### DIFF
--- a/playground/server/api/vectorize/index.get.ts
+++ b/playground/server/api/vectorize/index.get.ts
@@ -2,6 +2,5 @@ export default eventHandler(async (event) => {
   const { query } = await getValidatedQuery(event, z.object({
     query: z.array(z.number())
   }).parse)
-  const index = hubVectorize('example')
-  return index.query(query)
+  return hubVectorize('example')?.query(query)
 })

--- a/playground/server/api/vectorize/index.get.ts
+++ b/playground/server/api/vectorize/index.get.ts
@@ -2,5 +2,5 @@ export default eventHandler(async (event) => {
   const { query } = await getValidatedQuery(event, z.object({
     query: z.array(z.number())
   }).parse)
-  return hubVectorize('example')?.query(query)
+  return hubVectorize('example')?.query(query) || []
 })

--- a/src/runtime/vectorize/server/utils/vectorize.ts
+++ b/src/runtime/vectorize/server/utils/vectorize.ts
@@ -30,7 +30,7 @@ type VectorizeIndexes = keyof RuntimeConfig['hub']['vectorize'] & string
  *
  * @see https://hub.nuxt.com/docs/features/vectorize
  */
-export function hubVectorize(index: VectorizeIndexes): Vectorize {
+export function hubVectorize(index: VectorizeIndexes): Vectorize | undefined {
   requireNuxtHubFeature('vectorize')
 
   if (_vectorize[index]) {
@@ -52,10 +52,7 @@ export function hubVectorize(index: VectorizeIndexes): Vectorize {
     return _vectorize[index]
   }
   if (import.meta.dev && !hub.remote) {
-    throw createError({
-      statusCode: 500,
-      message: 'hubVectorize() is only supported with remote storage in development mode'
-    })
+    return undefined
   }
 
   throw createError(`Missing Cloudflare Vectorize binding (${bindingName})`)


### PR DESCRIPTION
Continue of #396 