### PR TITLE
feat: add hub `test` env as well as supporting nuxt test option

### DIFF
--- a/playground/test/basic.test.ts
+++ b/playground/test/basic.test.ts
@@ -1,0 +1,32 @@
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import { setup, $fetch } from '@nuxt/test-utils/e2e'
+
+describe('ssr', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('..', import.meta.url)),
+    dev: true
+  })
+
+  it('Clear todos table', async () => {
+    await $fetch('/api/_hub/database/query', {
+      method: 'POST',
+      body: {
+        query: 'DELETE FROM todos'
+      }
+    })
+  })
+
+  it('List todos', async () => {
+    const todos = await $fetch('/api/todos')
+    expect(todos).toMatchObject([])
+  })
+
+  it('Create todo', async () => {
+    const todo = await $fetch('/api/todos', {
+      method: 'POST',
+      body: { title: 'Test todo' }
+    })
+    expect(todo).toMatchObject({ id: expect.any(Number), title: 'Test todo' })
+  })
+})

--- a/src/utils/wrangler.ts
+++ b/src/utils/wrangler.ts
@@ -6,18 +6,19 @@ import type { HubConfig } from '../features'
 // Please update nuxt-hub/cli preview command as well
 export function generateWrangler(nuxt: Nuxt, hub: HubConfig) {
   const wrangler: { [key: string]: any } = {}
+  const name = hub.env === 'test' ? 'test' : 'default'
 
   if (hub.analytics && !hub.remote) {
     wrangler['analytics_engine_datasets'] = [{
       binding: 'ANALYTICS',
-      dataset: 'default'
+      dataset: name
     }]
   }
 
   if (hub.blob && !hub.remote) {
     wrangler['r2_buckets'] = [{
       binding: 'BLOB',
-      bucket_name: 'default'
+      bucket_name: name
     }]
   }
 
@@ -27,14 +28,14 @@ export function generateWrangler(nuxt: Nuxt, hub: HubConfig) {
     if (hub.kv && !hub.remote) {
       wrangler['kv_namespaces'].push({
         binding: 'KV',
-        id: 'kv_default'
+        id: `kv_${name}`
       })
     }
 
     if (hub.cache) {
       wrangler['kv_namespaces'].push({
         binding: 'CACHE',
-        id: 'cache_default'
+        id: `cache_${name}`
       })
     }
   }
@@ -42,8 +43,8 @@ export function generateWrangler(nuxt: Nuxt, hub: HubConfig) {
   if (hub.database && !hub.remote) {
     wrangler['d1_databases'] = [{
       binding: 'DB',
-      database_name: 'default',
-      database_id: 'default'
+      database_name: name,
+      database_id: name
     }]
   }
 


### PR DESCRIPTION
This will help when working with tests so NuxtHub will use another dataset, useful to avoid writing on the development database.

Options to enable the hub test env:
- `NUXT_HUB_ENV=test`
- `nuxi dev --hub-env test`
- Running the dev server within Vitest with:
```ts
// basic.test.ts
import { fileURLToPath } from 'node:url'
import { describe } from 'vitest'
import { setup, $fetch } from '@nuxt/test-utils/e2e'

describe('test env', async () => {
  await setup({
    rootDir: fileURLToPath(new URL('..', import.meta.url)),
    dev: true
  })
  // ...
})
```