### PR TITLE
feat(blob serve): stream option implemented to prevent videos downloading

### DIFF
--- a/docs/content/1.docs/2.features/blob.md
+++ b/docs/content/1.docs/2.features/blob.md
@@ -90,6 +90,8 @@ do {
 
 Returns a blob's data and sets `Content-Type`, `Content-Length` and `ETag` headers.
 
+#### Image
+
 ::code-group
 ```ts [server/routes/images/[...pathname\\].get.ts]
 export default eventHandler(async (event) => {
@@ -101,6 +103,34 @@ export default eventHandler(async (event) => {
 ```vue [pages/index.vue]
 <template>
   <img src="/images/my-image.jpg">
+</template>
+```
+::
+
+#### Video
+
+::callout
+Add `stream: true` option to prevent videos downloading.
+::
+
+::code-group
+```ts [server/routes/videos/[...pathname\\].get.ts]
+export default eventHandler(async (event) => {
+  const { pathname } = getRouterParams(event)
+
+  return hubBlob().serve(event, pathname, {
+    stream: true
+  })
+})
+```
+```vue [pages/index.vue]
+<template>
+  <video
+    controls
+    playsinline
+    controlsList="nodownload"
+    src="/videos/my-video.mp4"
+  />
 </template>
 ```
 ::
@@ -832,6 +862,14 @@ interface BlobListResult {
   hasMore: boolean
   cursor?: string
   folders?: string[]
+}
+```
+
+### `BlobServeOptions`
+
+```ts
+interface BlobServeOptions {
+  stream: boolean
 }
 ```
 

--- a/src/types/blob.ts
+++ b/src/types/blob.ts
@@ -262,3 +262,7 @@ export interface BlobCredentials {
    */
   sessionToken: string
 }
+
+export interface BlobServeOptions {
+  stream: boolean
+}


### PR DESCRIPTION
It solves issue: https://github.com/nuxt-hub/core/issues/444

I didn't work with videos streaming enough. Maybe you have a better solution instead of this part:
```ts
const referrer = getHeader(event, 'referer')
const range = getHeader(event, 'range')

if (!referrer || !range) {
  throw createError({
    statusCode: 403,
    message: 'Unauthorized'
  })
}
```

But in general, I expect something like this and the code parts mentioned in the PR's files changes what has to be done.