### PR TITLE
fix(blob): return null for get() with remote enabled

### DIFF
--- a/playground/server/api/blob/get/[...pathname].get.ts
+++ b/playground/server/api/blob/get/[...pathname].get.ts
@@ -7,5 +7,12 @@ export default eventHandler(async (event) => {
 
   console.log('blob', blob)
 
+  if (!blob) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Blob not found'
+    })
+  }
+
   return blob
 })

--- a/src/runtime/blob/server/utils/blob.ts
+++ b/src/runtime/blob/server/utils/blob.ts
@@ -408,10 +408,15 @@ export function proxyHubBlob(projectUrl: string, secretKey?: string, headers?: H
         method: 'GET'
       })
     },
-    async get(pathname: string): Promise<Blob> {
+    async get(pathname: string): Promise<Blob | null> {
       return await blobAPI(`/${encodeURIComponent(pathname)}`, {
         method: 'GET',
         responseType: 'blob'
+      }).catch((e) => {
+        if (e.status === 404) {
+          return null
+        }
+        throw e
       })
     },
     async del(pathnames: string | string[]) {


### PR DESCRIPTION
resolves #450 