### PR TITLE
docs: improve environment variables part

### DIFF
--- a/docs/content/docs/1.getting-started/3.deploy.md
+++ b/docs/content/docs/1.getting-started/3.deploy.md
@@ -210,16 +210,19 @@ NuxtHub automatically copies all your project's environment variables to your Gi
 
 When encrypting an environment variable in the NuxtHub Admin, a GitHub actions secret will be created in your repository.
 
+You can view the environment variables and secrets synchronized by NuxtHub by navigating to **Repository Settings -> Secrets and variables -> Actions** on GitHub.
+
 ::warning
-If you have a private repository on a free GitHub account or organization, NuxtHub won't be able to sync the env variables & secrets as GitHub repository environments (production / preview) are not available.
+If you have a private repository on a free GitHub account or organization, NuxtHub won't be able to sync the env variables & secrets as GitHub repository environments (production / preview) are not available. In this case, you must manually set up the environment variables by navigating to **Repository Settings -> Secrets and variables -> Actions** on GitHub.
 ::
 
-In order to use GitHub Actions secret, you need to update the GitHub Actions workflow to use the secret as environment variable:
+In order to use GitHub Actions variables and secrets, you need to update your workflow to expose them as environment variables:
 
 ```diff [.github/workflows/nuxthub.yml]
   - name: Build application
     run: pnpm run build
 +   env:
++     NUXT_PUBLIC_VAR: ${{ vars.NUXT_PUBLIC_VAR }}
 +     NUXT_UI_PRO_LICENSE: ${{ secrets.NUXT_UI_PRO_LICENSE }}
 ```
 


### PR DESCRIPTION
This PR enhances our documentation on managing environment variables within GitHub workflows.

1. It clarifies where to locate these variables and secrets in GitHub repository settings, helping users verify NuxtHub’s synchronization.
2. For private repositories on free GitHub accounts or organizations, the documentation now explains that environment variables must be manually configured and provides clear instructions on where to do so.
3. An example workflow has also been updated to demonstrate the use of both a public variable and a secret for private variables.