### PR TITLE
docs(gitlab-ci): adding gitlab-ci documentation

### DIFF
--- a/docs/content/docs/1.getting-started/3.deploy.md
+++ b/docs/content/docs/1.getting-started/3.deploy.md
@@ -263,21 +263,24 @@ When multiple projects are linked to the same repository, the [`project-key`](#i
 
 ## Gitlab CI
 
-This section will guide you to implement the gitlab ci.
-The integration with Gitlab CI builds on the [Usage with CI/CD](https://hub.nuxt.com/docs/getting-started/deploy#usage-with-cicd) Section,
+This section will guide you to implement the GitLab CI.
+The integration with GitLab CI builds on the [Usage with CI/CD](https://hub.nuxt.com/docs/getting-started/deploy#usage-with-cicd) section,
 make sure you have those two variables `NUXT_HUB_PROJECT_KEY` and `NUXT_HUB_USER_TOKEN`
 
 ### Setup Gitlab CI Variables
 
-Its bad practice to place the user token inside the repository.
+::note
+It is bad practice to place the user token inside the repository.
+Therefore, we place it in the GitLab CI Variables
+::
 
-1. Open your Repository (on Gitlab) > Settings > CI/CD > Variables
+1. Open your Repository (on GitLab) > Settings > CI/CD > Variables
 2. Click on _Add variable_
 3. Set Visibility to Masked and hidden
-4. Remove Protected Flag (since we may use this variable also on non-protected branches)
-5. Give a Key name (e.g.: NUXT_HUB_USER_TOKEN)
-6. Paste your **NUXT_HUB_USER_TOKEN**
-7. Click Add Variable
+4. Remove protected Flag (since we may use this variable also on non-protected branches)
+5. Give a Key name = `NUXT_HUB_USER_TOKEN`
+6. Paste your `NUXT_HUB_USER_TOKEN`
+7. Click Add variable
 
 ::note
 The `NUXT_HUB_PROJECT_KEY` is used later in [Configure Projects for Gitlab](#configure-projects-for-gitlab).
@@ -285,7 +288,7 @@ The `NUXT_HUB_PROJECT_KEY` is used later in [Configure Projects for Gitlab](#con
 
 ### For Monorepos with multiple apps (Optional Step)
 
-::info
+::note
 if you do not use a monorepo with multiple apps, jump to [Configure Projects for Gitlab](#configure-projects-for-gitlab)
 ::
 
@@ -295,7 +298,7 @@ then we make sure our pipelines can run parallel.
 1. Create in your repository root a `.gitlab-ci.yml`
 2. paste the following configuration
 
-```gitlab-ci
+```yml
 # if one job fails, pipeline should fail
 workflow:
   auto_cancel:
@@ -332,14 +335,15 @@ add_manual_triggers:
       - local: ".manual-triggers.yml"
 ```
 
-Do not forget to change the paths to your needs.
+Change the paths to your needs.
 This configuration separates your main pipeline from child pipelines.
-Each project has its own `.gitlab-ci.yml`.
+
+Each project (app) has its own `.gitlab-ci.yml`.
 Those child pipelines are only triggered if changes are made in their app folder.
 
 Create now a `.manual-triggers.yml` in your project root.
 
-```gitlab-ci
+```yml
 workflow:
   auto_cancel:
     on_job_failure: all
@@ -370,25 +374,25 @@ callback:
     - echo "manual triggers set"
 ```
 
-Sometimes gitlab changes are not recognized (previous pipeline failed new push has no changes in app folder),
+Sometimes gitlab changes are not recognized (previous pipeline failed and new push has no changes in app folder),
 for that case, we added manual triggers for our child pipelines.
 
 ::warning
 With the options `depends` and `workflow.auto_cancel.on_job_failure: all` a pipeline is failed, if one job fails.
-This assures a clean main / staging branch.
+This assures a clean main / staging branch. Change it to your needs.
 ::
 
 ### Configure Projects for Gitlab
 
-::info 
-If you have a monorepo with multiple apps, do this step with each of your project.
-Create in each project a `.gitlab-ci.yml`. That will apply the link to the child pipeline from the main `.gitlab-ci.yml`.
+::note
+If you have a monorepo with multiple projects (apps), do this step with each of your project.
+Create in each project a `.gitlab-ci.yml`. That will apply the link to the child pipeline from the root `.gitlab-ci.yml`.
 ::
 
-1. create a `.gitlab-ci.yml` in your repository root (or in monorepo --> in each app project)
+1. create a `.gitlab-ci.yml` in your repository root (or in monorepo -> in each app project)
 2. Paste the following configuration
 
-```gitlab-ci
+```yml
 # if one job fails, pipeline should fail
 workflow:
   auto_cancel:
@@ -409,19 +413,24 @@ deploy_project_a:
   script:
     - echo "Deploying project_a app..."
     - cd $APP_PATH
-    - bun install # you can not use node_modules from cache here, since nuxthub needs write access
-    - bunx nuxthub deploy # if you setup your variables correctly this should deploy everything
+    # you can not use node_modules from cache, since nuxthub needs write access
+    - bun install
+    # if you set up your variables correctly this should deploy successfully
+    - bunx nuxthub deploy 
   rules:
-    - if: '$CI_COMMIT_BRANCH == "staging" || $CI_COMMIT_BRANCH == "main"' # here we configure auto deploy on branch: staging and main
+    # here we configure auto deploy on branch: staging and main
+    - if: '$CI_COMMIT_BRANCH == "staging" || $CI_COMMIT_BRANCH == "main"'
     - when: manual
-    
-  # you might need to add at least one job which returns a successful state
-  # otherwise gitlab will mark your pipeline as blocked, if the auto deploy rule does not apply.
 ```
 
-::info
+::warning
+If your pipeline is marked as blocked,
+make sure your project (child) pipelines have at least one successful job.
+::
+
+::tip
 You can always deploy from your working branches, just use the manual trigger.
-Deployed Branches different from 'main' (or what you configured in nuxthub dashboard as your main) will be marked as `preview`
+Deployed branches different from 'main' (or what you configured in nuxthub dashboard as your main) will be marked as `preview`
 ::
 
 ## Cloudflare Pages CI

--- a/docs/content/docs/1.getting-started/3.deploy.md
+++ b/docs/content/docs/1.getting-started/3.deploy.md
@@ -121,6 +121,7 @@ The GitHub Workflow added to your repository is automatically tailored to your p
 
 We support pnpm, yarn, npm and Corepack. If you use a different package manager, you can customise the generated `nuxthub.yml` GitHub Action.
 
+::code-collapse
 ```yaml [.github/workflows/nuxthub.yml]
 name: Deploy to NuxtHub
 on: push
@@ -160,6 +161,7 @@ jobs:
         uses: nuxt-hub/action@v1
         id: deploy
 ```
+::
 
 ### Options
 
@@ -180,7 +182,6 @@ The following input parameters can be provided to the GitHub Action. Learn more 
 #### Outputs
 
 The GitHub Action provides the following outputs that you can use in subsequent workflow steps.
-
 
 ::field-group
   ::field{name="environment" type="'production' | 'preview'"}
@@ -261,15 +262,15 @@ When multiple projects are linked to the same repository, the [`project-key`](#i
 
 - Separate applications should be deployed using different workflow jobs.
 
-## Gitlab CI
+## GitLab CI
 
 This section will guide you to implement the GitLab CI.
 The integration with GitLab CI builds on the [Usage with CI/CD](https://hub.nuxt.com/docs/getting-started/deploy#usage-with-cicd) section,
-make sure you have those two variables `NUXT_HUB_PROJECT_KEY` and `NUXT_HUB_USER_TOKEN`
+make sure you have those two variables `NUXT_HUB_PROJECT_KEY` and `NUXT_HUB_USER_TOKEN`.
 
-### Setup Gitlab CI Variables
+### User Token Variable
 
-::note
+::important
 It is good practice to place the user token inside GitLab CI Variables.
 ::
 
@@ -278,119 +279,20 @@ It is good practice to place the user token inside GitLab CI Variables.
 3. Set Visibility to Masked and hidden
 4. Remove protected Flag (since we may use this variable also on non-protected branches)
 5. Give a Key name = `NUXT_HUB_USER_TOKEN`
-6. Paste your `NUXT_HUB_USER_TOKEN`
+6. Paste your `NUXT_HUB_USER_TOKEN` — Your personal token, available in **User settings** → **Tokens** in the [NuxtHub Admin](https://admin.hub.nuxt.com)
 7. Click Add variable
 
 ::note
-The `NUXT_HUB_PROJECT_KEY` is used later in [Configure Projects for Gitlab](#configure-projects-for-gitlab).
+The `NUXT_HUB_PROJECT_KEY` is used later in [Configure Projects for GitLab](#configure-projects-for-gitlab).
 ::
 
-### For Monorepos with multiple apps (Optional Step)
+### Project Configuration
 
-::note
-If you do not use a monorepo with multiple apps, jump to [Configure Projects for Gitlab](#configure-projects-for-gitlab).
-::
-
-If you have a monorepo with multiple apps (e.g. ./apps/project-a),
-then we make sure our pipelines can run parallel.
-
-1. Create in your repository root a `.gitlab-ci.yml`
-2. paste the following configuration
-
-```yml
-# if one job fails, pipeline should fail
-workflow:
-  auto_cancel:
-    on_job_failure: all
-stages:
-  - trigger_apps
-
-trigger_project_a:
-  stage: trigger_apps
-  rules:
-    - changes:
-        - "apps/project_a/**/*"
-  trigger:
-    strategy: depend
-    include:
-      - local: "apps/project_a/.gitlab-ci.yml"
-
-trigger_project_b:
-  stage: trigger_apps
-  rules:
-    - changes:
-        - "apps/project_b/**/*"
-  trigger:
-    strategy: depend
-    include:
-      - local: "apps/project_b/.gitlab-ci.yml"
-  
-add_manual_triggers:
-  stage: trigger_apps
-  trigger:
-    strategy: depend
-    include:
-      - local: ".manual-triggers.yml"
-```
-
-Change the paths to your needs.
-This configuration separates your main pipeline from child pipelines.
-
-Each project (app) has its own `.gitlab-ci.yml`.
-Those child pipelines are only triggered if changes are made in their app folder.
-
-Create now a `.manual-triggers.yml` in your project root.
-
-```yml
-workflow:
-  auto_cancel:
-    on_job_failure: all
-
-stages:
-  - trigger_apps
-  - callback
-
-trigger_project_a:
-  stage: trigger_apps
-  when: manual
-  trigger:
-    strategy: depend
-    include:
-      - local: "apps/project_a/.gitlab-ci.yml"
-
-trigger_project_b:
-  stage: trigger_apps
-  when: manual
-  trigger:
-    strategy: depend
-    include:
-      - local: "apps/project_b/.gitlab-ci.yml"
-          
-callback:
-  stage: callback
-  script:
-    - echo "manual triggers set"
-```
-
-Sometimes gitlab changes are not recognized (previous pipeline failed and new push has no changes in app folder),
-for that case, we added manual triggers for our child pipelines.
-
-::warning
-With the options `depends` and `workflow.auto_cancel.on_job_failure: all` a pipeline is failed, if one job fails.
-This assures a clean main / staging branch. Change it to your needs.
-::
-
-### Configure Projects for Gitlab
-
-::note
-If you have a monorepo with multiple projects (apps), do this step with each of your project.
-Create in each project a `.gitlab-ci.yml`. That will apply the link to the child pipeline from the root `.gitlab-ci.yml`.
-::
-
-1. create a `.gitlab-ci.yml` in your repository root (or in monorepo -> in each app project)
+1. Create a `.gitlab-ci.yml` in your repository root
 2. Paste the following configuration
 
-```yml
+::code-collapse
+```yml [.gitlab-ci.yml]
 # if one job fails, pipeline should fail
 workflow:
   auto_cancel:
@@ -405,7 +307,7 @@ stages:
   - deploy
   - callback
 
-deploy_project_a:
+deploy_project:
   stage: deploy
   # here we use Bun, you can change this.
   image: "oven/bun:slim"
@@ -420,7 +322,7 @@ deploy_project_a:
     # here we configure auto deploy on branch: staging and main
     - if: '$CI_COMMIT_BRANCH == "staging" || $CI_COMMIT_BRANCH == "main"'
       
-manual_deploy_project_a:
+manual_deploy_project:
   stage: deploy
   image: "oven/bun:slim"
   when: manual
@@ -435,17 +337,114 @@ callback:
   script:
     - echo "Deploy reached."
 ```
+::
+
+::note
+If you have a monorepo with multiple projects (apps), do this step for each of your project (e.g. `./apps/project-foo/.gitlab-ci.yml`). Then follow the [Monorepo Setup](#monorepo-setup-1) section.
+::
+
 
 ::warning
 The `callback` job is needed to mark the pipeline as successfully,
-especially if `deploy_project_a` has not run.
+especially if `deploy_project` has not run. :br
 You can avoid this by setting `allow-failure: true` but this will result in other drawbacks.
 Or simply deploy on every branch, which results in more traffic.
 ::
 
 ::tip
 You can always deploy from your working branches, just use the manual trigger.
-Deployed branches different from 'main' (or what you configured in nuxthub dashboard as your main) will be marked as `preview`
+Deployed branches different from 'main' (or what you configured in nuxthub dashboard as your main) will be marked as `preview`.
+::
+
+### Monorepo Setup
+
+If you have a monorepo with multiple apps (e.g. `./apps/project-foo`), then we make sure our pipelines can run parallel.
+
+1. Create in your repository root a `.gitlab-ci.yml`
+2. Paste the following configuration
+
+::code-collapse
+```yml [.gitlab-ci.yml]
+# if one job fails, pipeline should fail
+workflow:
+  auto_cancel:
+    on_job_failure: all
+stages:
+  - trigger_apps
+
+trigger_project_a:
+  stage: trigger_apps
+  rules:
+    - changes:
+        - "apps/project-foo/**/*"
+  trigger:
+    strategy: depend
+    include:
+      - local: "apps/project-foo/.gitlab-ci.yml"
+
+trigger_project_b:
+  stage: trigger_apps
+  rules:
+    - changes:
+        - "apps/project-bar/**/*"
+  trigger:
+    strategy: depend
+    include:
+      - local: "apps/project-bar/.gitlab-ci.yml"
+  
+add_manual_triggers:
+  stage: trigger_apps
+  trigger:
+    strategy: depend
+    include:
+      - local: ".manual-triggers.yml"
+```
+::
+
+::note
+Change the paths to your own project paths.
+::
+
+This configuration separates your main pipeline from child pipelines, each project (app) has its own `.gitlab-ci.yml` Those child pipelines are only triggered if changes are made in their app folder.
+
+Sometimes GitLab changes are not recognized (previous pipeline failed and new push has no changes in app folder), for that case, you can add manual triggers for the child pipelines by adding a `.manual-triggers.yml` in the project root.
+
+::code-collapse
+```yml [.manual-triggers.yml]
+workflow:
+  auto_cancel:
+    on_job_failure: all
+
+stages:
+  - trigger_apps
+  - callback
+
+trigger_project_a:
+  stage: trigger_apps
+  when: manual
+  trigger:
+    strategy: depend
+    include:
+      - local: "apps/project-foo/.gitlab-ci.yml"
+
+trigger_project_b:
+  stage: trigger_apps
+  when: manual
+  trigger:
+    strategy: depend
+    include:
+      - local: "apps/project-bar/.gitlab-ci.yml"
+          
+callback:
+  stage: callback
+  script:
+    - echo "manual triggers set"
+```
+::
+
+::warning
+With the options `depends` and `workflow.auto_cancel.on_job_failure: all` a pipeline is failed, if one job fails.
+This assures a clean main / staging branch. Change it to your needs.
 ::
 
 ## Cloudflare Pages CI
@@ -473,7 +472,7 @@ For that, you need to create the necessary resources in your Cloudflare account 
 You only need to create these resources if you have explicitly enabled them in the Hub Config.
 ::
 
-Then, create a [Cloudflare Pages project](https://dash.cloudflare.com/?to=/:account/pages/new/provider/github) and link your GitHub or Gitlab repository and choose the Nuxt Framework preset in the build settings.
+Then, create a [Cloudflare Pages project](https://dash.cloudflare.com/?to=/:account/pages/new/provider/github) and link your GitHub or GitLab repository and choose the Nuxt Framework preset in the build settings.
 
 Once your project is created, open the `Settings` tab and set:
 - Runtime > Compatibility flags

--- a/docs/content/docs/1.getting-started/3.deploy.md
+++ b/docs/content/docs/1.getting-started/3.deploy.md
@@ -270,8 +270,7 @@ make sure you have those two variables `NUXT_HUB_PROJECT_KEY` and `NUXT_HUB_USER
 ### Setup Gitlab CI Variables
 
 ::note
-It is bad practice to place the user token inside the repository.
-Therefore, we place it in the GitLab CI Variables
+It is good practice to place the user token inside GitLab CI Variables.
 ::
 
 1. Open your Repository (on GitLab) > Settings > CI/CD > Variables
@@ -289,7 +288,7 @@ The `NUXT_HUB_PROJECT_KEY` is used later in [Configure Projects for Gitlab](#con
 ### For Monorepos with multiple apps (Optional Step)
 
 ::note
-if you do not use a monorepo with multiple apps, jump to [Configure Projects for Gitlab](#configure-projects-for-gitlab)
+If you do not use a monorepo with multiple apps, jump to [Configure Projects for Gitlab](#configure-projects-for-gitlab).
 ::
 
 If you have a monorepo with multiple apps (e.g. ./apps/project-a),

--- a/docs/content/docs/1.getting-started/3.deploy.md
+++ b/docs/content/docs/1.getting-started/3.deploy.md
@@ -305,7 +305,6 @@ workflow:
     on_job_failure: all
 stages:
   - trigger_apps
-  - add_manual_triggers
 
 trigger_project_a:
   stage: trigger_apps
@@ -328,7 +327,7 @@ trigger_project_b:
       - local: "apps/project_b/.gitlab-ci.yml"
   
 add_manual_triggers:
-  stage: add_manual_triggers
+  stage: trigger_apps
   trigger:
     strategy: depend
     include:
@@ -405,6 +404,7 @@ variables:
 # add additional steps as needed
 stages:
   - deploy
+  - callback
 
 deploy_project_a:
   stage: deploy
@@ -420,12 +420,28 @@ deploy_project_a:
   rules:
     # here we configure auto deploy on branch: staging and main
     - if: '$CI_COMMIT_BRANCH == "staging" || $CI_COMMIT_BRANCH == "main"'
-    - when: manual
+      
+manual_deploy_project_a:
+  stage: deploy
+  image: "oven/bun:slim"
+  when: manual
+  script:
+    - echo "Deploying project_a app..."
+    - cd $APP_PATH
+    - bun install
+    - bunx nuxthub deploy
+
+callback:
+  stage: callback
+  script:
+    - echo "Deploy reached."
 ```
 
 ::warning
-If your pipeline is marked as blocked,
-make sure your project (child) pipelines have at least one successful job.
+The `callback` job is needed to mark the pipeline as successfully,
+especially if `deploy_project_a` has not run.
+You can avoid this by setting `allow-failure: true` but this will result in other drawbacks.
+Or simply deploy on every branch, which results in more traffic.
 ::
 
 ::tip

--- a/docs/content/docs/1.getting-started/3.deploy.md
+++ b/docs/content/docs/1.getting-started/3.deploy.md
@@ -496,5 +496,4 @@ Go back to the `Deployment` tab and retry the last deployment by clicking on `..
 
 ::tip
 Once the deployment is done, you should be able to use `npx nuxt dev --remote` after [configuring the remote storage](/docs/getting-started/remote-storage#self-hosted)
-
 ::

--- a/docs/content/docs/1.getting-started/3.deploy.md
+++ b/docs/content/docs/1.getting-started/3.deploy.md
@@ -261,6 +261,128 @@ When multiple projects are linked to the same repository, the [`project-key`](#i
 
 - Separate applications should be deployed using different workflow jobs.
 
+## Gitlab CI
+
+This section will guide you to implement the gitlab ci.
+The integration with Gitlab CI builds on the [Usage with CI/CD](https://hub.nuxt.com/docs/getting-started/deploy#usage-with-cicd) Section,
+make sure you have those two variables `NUXT_HUB_PROJECT_KEY` and `NUXT_HUB_USER_TOKEN`
+
+### Setup Gitlab CI Variables
+
+Its bad practice to place the user token inside the repository.
+
+1. Open your Repository (on Gitlab) > Settings > CI/CD > Variables
+2. Click on _Add variable_
+3. Set Visibility to Masked and hidden
+4. Remove Protected Flag (since we may use this variable also on non-protected branches)
+5. Give a Key name (e.g.: NUXT_HUB_USER_TOKEN)
+6. Paste your **NUXT_HUB_USER_TOKEN**
+7. Click Add Variable
+
+::note
+The `NUXT_HUB_PROJECT_KEY` is used later in [Configure Projects for Gitlab](#configure-projects-for-gitlab).
+::
+
+### For Monorepos with multiple apps (Optional Step)
+
+::info
+if you do not use a monorepo with multiple apps, jump to [Configure Projects for Gitlab](#configure-projects-for-gitlab)
+::
+
+If you have a monorepo with multiple apps (e.g. ./apps/project-a),
+then we make sure our pipelines can run parallel.
+
+1. Create in your repository root a `.gitlab-ci.yml`
+2. paste the following configuration
+
+```gitlab-ci
+# if one job fails, pipeline should fail
+workflow:
+  auto_cancel:
+    on_job_failure: all
+stages:
+  - trigger_apps
+  - add_manual_triggers
+
+trigger_project_a:
+  stage: trigger_apps
+  rules:
+    - changes:
+        - "apps/project_a/**/*"
+  trigger:
+    strategy: depend
+    include:
+      - local: "apps/project_a/.gitlab-ci.yml"
+
+trigger_project_b:
+  stage: trigger_apps
+  rules:
+    - changes:
+        - "apps/project_b/**/*"
+  trigger:
+    strategy: depend
+    include:
+      - local: "apps/project_b/.gitlab-ci.yml"
+  
+add_manual_triggers:
+  stage: add_manual_triggers
+  trigger:
+    strategy: depend
+    include:
+      - local: ".manual-triggers.yml"
+```
+
+Do not forget to change the paths to your needs.
+This configuration separates your main pipeline from child pipelines.
+Each project has its own `.gitlab-ci.yml`.
+Those child pipelines are only triggered if changes are made in their app folder.
+
+Create now a `.manual-triggers.yml` in your project root.
+
+```gitlab-ci
+workflow:
+  auto_cancel:
+    on_job_failure: all
+
+stages:
+  - trigger_apps
+  - callback
+
+trigger_project_a:
+  stage: trigger_apps
+  when: manual
+  trigger:
+    strategy: depend
+    include:
+      - local: "apps/project_a/.gitlab-ci.yml"
+
+trigger_project_b:
+  stage: trigger_apps
+  when: manual
+  trigger:
+    strategy: depend
+    include:
+      - local: "apps/project_b/.gitlab-ci.yml"
+          
+callback:
+  stage: callback
+  script:
+    - echo "manual triggers set"
+```
+
+Sometimes gitlab changes are not recognized (previous pipeline failed new push has no changes in app folder),
+for that case, we added manual triggers for our child pipelines.
+
+::warning
+With the options `depends` and `workflow.auto_cancel.on_job_failure: all` a pipeline is failed, if one job fails.
+This assures a clean main / staging branch.
+::
+
+### Configure Projects for Gitlab
+
+This step needs to be done for every project in your repository.
+
+
 ## Cloudflare Pages CI
 
 Importing an existing Cloudflare Pages project that is already linked to a Git repository will use [Cloudflare Pages CI](https://pages.cloudflare.com) to deploy your project.

--- a/docs/content/docs/1.getting-started/3.deploy.md
+++ b/docs/content/docs/1.getting-started/3.deploy.md
@@ -380,8 +380,49 @@ This assures a clean main / staging branch.
 
 ### Configure Projects for Gitlab
 
-This step needs to be done for every project in your repository.
+::info 
+If you have a monorepo with multiple apps, do this step with each of your project.
+Create in each project a `.gitlab-ci.yml`. That will apply the link to the child pipeline from the main `.gitlab-ci.yml`.
+::
 
+1. create a `.gitlab-ci.yml` in your repository root (or in monorepo --> in each app project)
+2. Paste the following configuration
+
+```gitlab-ci
+# if one job fails, pipeline should fail
+workflow:
+  auto_cancel:
+    on_job_failure: all
+    
+variables: 
+  APP_PATH: "PATH/TO/YOUR/APP"
+  NUXT_HUB_PROJECT_KEY: "YOUR_NUXT_HUB_PROJECT_KEY"
+
+# add additional steps as needed
+stages:
+  - deploy
+
+deploy_project_a:
+  stage: deploy
+  # here we use Bun, you can change this.
+  image: "oven/bun:slim"
+  script:
+    - echo "Deploying project_a app..."
+    - cd $APP_PATH
+    - bun install # you can not use node_modules from cache here, since nuxthub needs write access
+    - bunx nuxthub deploy # if you setup your variables correctly this should deploy everything
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "staging" || $CI_COMMIT_BRANCH == "main"' # here we configure auto deploy on branch: staging and main
+    - when: manual
+    
+  # you might need to add at least one job which returns a successful state
+  # otherwise gitlab will mark your pipeline as blocked, if the auto deploy rule does not apply.
+```
+
+::info
+You can always deploy from your working branches, just use the manual trigger.
+Deployed Branches different from 'main' (or what you configured in nuxthub dashboard as your main) will be marked as `preview`
+::
 
 ## Cloudflare Pages CI
 
@@ -430,4 +471,5 @@ Go back to the `Deployment` tab and retry the last deployment by clicking on `..
 
 ::tip
 Once the deployment is done, you should be able to use `npx nuxt dev --remote` after [configuring the remote storage](/docs/getting-started/remote-storage#self-hosted)
+
 ::


### PR DESCRIPTION
This Pull Request resolves #475 

Here I added a detailed documentation how to setup nuxthub with gitlab-ci.

Following features are mentioned:

- deploy with gitlab-ci (obviously) 
- Monorepo support
- Auto Deploy (default on pushes to staging and main)
- Manual triggers (benefit is reduction of overall internet traffic and run on demand if change detection not triggering)
- Bun support
- Job caching

I do not know if the mono repo stuff is maybe to much. Since you mentioned it for Github Actions its fair to also mention the how-to for gitlab.

Please review my changes, give critics and check grammar (no native english speaker, but did use grammar tools)

### Manual Trigger Setup
![Manual Trigger Setup](https://github.com/user-attachments/assets/e934775c-ffb3-40be-a40f-c89bff0c6d3b)

---

### Main auto deploy, manual trigger, success child pipeline
![Main auto deploy, manual trigger, success child pipeline](https://github.com/user-attachments/assets/096e4ffc-7cf7-4812-adc7-d8af0347b088)

---

### Successful pipeline
![Successful pipeline](https://github.com/user-attachments/assets/569521a8-6ac2-4ef7-9473-d0e2b1a055f9)

---

### Successful Main pipeline without app changes
![Successful Main pipeline without app changes](https://github.com/user-attachments/assets/2af80384-0e37-49ed-907c-8de80c125009)

