### PR TITLE
docs(deploy): add `NUXT_UI_PRO_LICENSE` variable fallback in Github Actions 

### DIFF
--- a/docs/content/docs/1.getting-started/3.deploy.md
+++ b/docs/content/docs/1.getting-started/3.deploy.md
@@ -224,7 +224,7 @@ In order to use GitHub Actions variables and secrets, you need to update your wo
     run: pnpm run build
 +   env:
 +     NUXT_PUBLIC_VAR: ${{ vars.NUXT_PUBLIC_VAR }}
-+     NUXT_UI_PRO_LICENSE: ${{ secrets.NUXT_UI_PRO_LICENSE }}
++     NUXT_UI_PRO_LICENSE: ${{ secrets.NUXT_UI_PRO_LICENSE || vars.NUXT_UI_PRO_LICENSE }}
 ```
 
 ::note


### PR DESCRIPTION
Spent a long time debugging this – if the NUXT_UI_PRO_LICENSE variable isn’t encrypted, it won’t work as expected. If the variable is generated for the workflow file (https://github.com/nuxt-hub/core/issues/509), this syntax is required to work in both encrypted and non-encrypted cases.