### PR TITLE
fix(mpu): missing content type on complete

### DIFF
--- a/src/runtime/blob/server/utils/blob.ts
+++ b/src/runtime/blob/server/utils/blob.ts
@@ -645,7 +645,7 @@ function getContentType(pathOrExtension?: string) {
 function mapR2ObjectToBlob(object: R2Object): BlobObject {
   return {
     pathname: object.key,
-    contentType: object.httpMetadata?.contentType,
+    contentType: object.httpMetadata?.contentType || getContentType(object.key),
     size: object.size,
     httpEtag: object.httpEtag,
     uploadedAt: object.uploaded,


### PR DESCRIPTION
Cloudflare multi-part upload does not return `httpMetadata` and `customMetadata` when the upload is complete. As we depend on `customMetadata` to find `contentType` of the file, this behavior leads to undefined `contentType`.

There are two solutions so far:

1. call `hubBlob().head(mpu.key)` in upload complete and re-fetch the information on file (adds one extra read operation on all uploads)
2. re-evaluate contentType using our `getContentType` if it's missing. This PR proposes this solution.