### PR TITLE
feat: send file mime to multi-part upload

### DIFF
--- a/src/runtime/blob/app/composables/useMultipartUpload.ts
+++ b/src/runtime/blob/app/composables/useMultipartUpload.ts
@@ -30,7 +30,10 @@ export function useMultipartUpload(
     pathname: string
     uploadId: string
   }>(prefix ? joinURL('/create', prefix, file.name) : joinURL('/create', file.name), {
-    method: 'POST'
+    method: 'POST',
+    headers: {
+      'x-nuxthub-file-content-type': file.type
+    }
   })
 
   const upload = (

--- a/src/runtime/blob/server/utils/blob.ts
+++ b/src/runtime/blob/server/utils/blob.ts
@@ -508,6 +508,11 @@ function createMultipartUploadHandler(
       pathname: z.string().min(1)
     }).parse)
 
+    options ||= {}
+    if (getHeader(event, 'x-nuxthub-file-content-type')) {
+      options.contentType ||= getHeader(event, 'x-nuxthub-file-content-type')
+    }
+
     try {
       const object = await createMultipartUpload(pathname, options)
       return {


### PR DESCRIPTION
Send the file type via HTTP headers and read it in the multi-part upload creation. 
