### PR TITLE
feat: support hub.workers

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -10,7 +10,7 @@ import { version } from '../package.json'
 import { generateWrangler } from './utils/wrangler'
 import { setupAI, setupCache, setupAnalytics, setupBlob, setupBrowser, setupOpenAPI, setupDatabase, setupKV, setupVectorize, setupBase, setupRemote, vectorizeRemoteCheck, type HubConfig } from './features'
 import type { ModuleOptions } from './types/module'
-import { addBuildHooks } from './utils/build'
+import { addBuildHooks, getNitroPreset } from './utils/build'
 
 export * from './types'
 
@@ -55,6 +55,8 @@ export default defineNuxtModule<ModuleOptions>({
       remoteManifest: undefined,
       // Local storage
       dir: '.data/hub',
+      // Workers support
+      workers: false,
       // NuxtHub features
       ai: false,
       analytics: false,
@@ -173,8 +175,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Production mode without remote storage
     if (!hub.remote && !nuxt.options.dev) {
-      // Make sure to fallback to cloudflare_pages preset
-      nuxt.options.nitro.preset = (nuxt.options.nitro.preset || 'cloudflare_pages').replace('-', '_')
+      nuxt.options.nitro.preset = getNitroPreset(hub, nuxt.options.nitro)
 
       if (!['cloudflare_pages', 'cloudflare_module', 'cloudflare_durable'].includes(nuxt.options.nitro.preset)) {
         log.error('NuxtHub is only compatible with the `cloudflare_pages`, `cloudflare_module` or `cloudflare_durable` presets.')

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -17,7 +17,7 @@ export interface ModuleOptions {
   /**
    * Set `true` if the project type is Workers.
    *
-   * If `nitro.experimental.websocket` is enabled, the preset will be set to `cloudflare_durable`, otherwise the preset will be `cloudflare-module`.
+   * If `nitro.experimental.websocket` is enabled, the preset will be set to `cloudflare_durable`, otherwise the preset will be `cloudflare_module`.
    *
    * @default false
    */

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -15,6 +15,14 @@ export interface ModuleHooks {
 
 export interface ModuleOptions {
   /**
+   * Set `true` if the project type is Workers.
+   *
+   * If `nitro.experimental.websocket` is enabled, the preset will be set to `cloudflare_durable`, otherwise the preset will be `cloudflare-module`.
+   *
+   * @default false
+   */
+  workers?: boolean
+  /**
    * Set `true` to enable AI for the project.
    *
    * Requires running `npx nuxthub link` for local development.

--- a/src/utils/build.ts
+++ b/src/utils/build.ts
@@ -3,8 +3,10 @@ import { logger } from '@nuxt/kit'
 import { join, resolve } from 'pathe'
 import { $fetch } from 'ofetch'
 import type { Nuxt } from '@nuxt/schema'
+import type { NitroConfig } from 'nitropack'
 import type { HubConfig } from '../features'
 import { applyRemoteDatabaseMigrations, applyRemoteDatabaseQueries } from '../runtime/database/server/utils/migrations/remote'
+import type { ModuleOptions } from '../types'
 
 const log = logger.withTag('nuxt:hub')
 
@@ -140,4 +142,16 @@ export function addBuildHooks(nuxt: Nuxt, hub: HubConfig) {
       }
     })
   }
+}
+
+export function getNitroPreset(hub: ModuleOptions, nitroOption: NitroConfig) {
+  if (nitroOption.preset) return nitroOption.preset.replace('-', '_')
+  if (hub.workers) {
+    if (nitroOption?.experimental?.websocket) {
+      return 'cloudflare_durable'
+    }
+    return 'cloudflare_module'
+  }
+
+  return 'cloudflare_pages'
 }


### PR DESCRIPTION
If `hub.workers: true`, the Nitro preset is`cloudflare_module` or `cloudflare_durable` if `nitro.experimental.websocket` is enabled.