### PR TITLE
fix(docs): update nitro.unjs.io links to nitro.build

### DIFF
--- a/docs/content/blog/1.beta.md
+++ b/docs/content/blog/1.beta.md
@@ -84,7 +84,7 @@ You can sign up for free and start building full-stack Nuxt applications at [adm
 
 ## Why NuxtHub?
 
-Starting with version 3, Nuxt is a complete full-stack framework thanks to its open server engine called [Nitro](https://nitro.unjs.io). It allows you to have hot module replacement on the server without rebuilding your Vue application, outstanding performance as well as deploying to many different hosting providers with zero configuration. Read more about it on the blog post: [Nuxt on the Edge](https://nuxt.com/blog/nuxt-on-the-edge).
+Starting with version 3, Nuxt is a complete full-stack framework thanks to its open server engine called [Nitro](https://nitro.build). It allows you to have hot module replacement on the server without rebuilding your Vue application, outstanding performance as well as deploying to many different hosting providers with zero configuration. Read more about it on the blog post: [Nuxt on the Edge](https://nuxt.com/blog/nuxt-on-the-edge).
 
 With this in mind, we wanted to provide you with a reliable platform to build and deploy your next idea while keeping the best developer experience.
 

--- a/docs/content/changelog/server-cache.md
+++ b/docs/content/changelog/server-cache.md
@@ -21,9 +21,9 @@ We are excited to announce that we have added a new page to your NuxtHub project
 :img{src="/images/changelog/server-cache.png" alt="NuxtHub Deployment Details" width="915" height="515"}
 
 It works with:
-- [`cachedEventHandler`](https://nitro.unjs.io/guide/cache#cached-event-handlers)
-- [`cachedFunction`](https://nitro.unjs.io/guide/cache#cached-functions)
-- [`routeRules`](https://nitro.unjs.io/guide/cache#caching-route-rules)
+- [`cachedEventHandler`](https://nitro.build/guide/cache#cached-event-handlers)
+- [`cachedFunction`](https://nitro.build/guide/cache#cached-functions)
+- [`routeRules`](https://nitro.build/guide/cache#caching-route-rules)
 
 ::callout{to="/docs/features/cache" icon="i-lucide-book"}
 Learn more about server cache.

--- a/docs/content/docs/2.features/cache.md
+++ b/docs/content/docs/2.features/cache.md
@@ -4,7 +4,7 @@ navigation.title: Cache
 description: Learn how to cache Nuxt pages, API routes and functions in with NuxtHub cache storage.
 ---
 
-NuxtHub Cache is powered by [Nitro's cache storage](https://nitro.unjs.io/guide/cache#customize-cache-storage) and uses [Cloudflare Workers KV](https://developers.cloudflare.com/kv) as the cache storage. It allows you to cache API routes, server functions, and pages in your application.
+NuxtHub Cache is powered by [Nitro's cache storage](https://nitro.build/guide/cache#customize-cache-storage) and uses [Cloudflare Workers KV](https://developers.cloudflare.com/kv) as the cache storage. It allows you to cache API routes, server functions, and pages in your application.
 
 ## Getting Started
 
@@ -19,7 +19,7 @@ export default defineNuxtConfig({
 ```
 
 ::note
-This option will configure [Nitro's cache storage](https://nitro.unjs.io/guide/cache#customize-cache-storage) to use [Cloudflare Workers KV](https://developers.cloudflare.com/kv) as well as creating a new storage namespace for your project when you deploy it.
+This option will configure [Nitro's cache storage](https://nitro.build/guide/cache#customize-cache-storage) to use [Cloudflare Workers KV](https://developers.cloudflare.com/kv) as well as creating a new storage namespace for your project when you deploy it.
 ::
 
 Once your Nuxt project is deployed, you can manage your cache entries in the `Cache` section of your project in the [NuxtHub admin](https://admin.hub.nuxt.com/).
@@ -48,8 +48,8 @@ export default cachedEventHandler((event) => {
 
 The above example will cache the response of the `/api/cached-route` route for 1 hour. The `getKey` function is used to generate the key for the cache entry.
 
-::note{to="https://nitro.unjs.io/guide/cache#options"}
-Read more about [Nitro Cache options](https://nitro.unjs.io/guide/cache#options).
+::note{to="https://nitro.build/guide/cache#options"}
+Read more about [Nitro Cache options](https://nitro.build/guide/cache#options).
 ::
 
 ## Server Functions Caching
@@ -80,7 +80,7 @@ The above example will cache the result of the `getRepoStarCached` function for 
 ::important
 It is important to note that the `event` argument should always be the first argument of the cached function. Nitro leverages `event.waitUntil` to keep the instance alive while the cache is being updated while the response is sent to the client.  
 :br
-[Read more about this in the Nitro docs](https://nitro.unjs.io/guide/cache#edge-workers).
+[Read more about this in the Nitro docs](https://nitro.build/guide/cache#edge-workers).
 ::
 
 ## Routes Caching
@@ -148,7 +148,7 @@ await useStorage('cache').clear('nitro:handlers')
 ```
 
 
-::note{to="https://nitro.unjs.io/guide/cache"}
+::note{to="https://nitro.build/guide/cache"}
 Read more about Nitro Cache.
 ::
 

--- a/docs/content/docs/2.features/vectorize.md
+++ b/docs/content/docs/2.features/vectorize.md
@@ -873,7 +873,7 @@ export default defineEventHandler(async (event) => {
 
 ### Bulk generation and import
 
-This example bulk generates vectors using a text embeddings AI model for all data within a database table, using [Nitro tasks](https://nitro.unjs.io/guide/tasks). You can run the task via Nuxt DevTools.
+This example bulk generates vectors using a text embeddings AI model for all data within a database table, using [Nitro tasks](https://nitro.build/guide/tasks). You can run the task via Nuxt DevTools.
 
 ```ts [server/tasks/generate-embeddings.ts]
 import { jobs } from "../database/schema";

--- a/docs/content/docs/3.recipes/2.drizzle.md
+++ b/docs/content/docs/3.recipes/2.drizzle.md
@@ -131,7 +131,7 @@ We also export the `sql`, `eq`, `and`, and `or` functions from `drizzle-orm` to 
 
 ### Seed the database (Optional)
 
-You can add a server task to populate your database with initial data. This uses [Nitro Tasks](https://nitro.unjs.io/guide/tasks), which is currently an experimental feature.
+You can add a server task to populate your database with initial data. This uses [Nitro Tasks](https://nitro.build/guide/tasks), which is currently an experimental feature.
 
 1. Update your nuxt.config.js:
 


### PR DESCRIPTION
This PR updates outdated Nitro documentation links from `nitro.unjs.io` to the new domain `nitro.build`