### PR TITLE
fix(types): add missing type definition for databaseMigrationsDirs

### DIFF
--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -142,7 +142,11 @@ export interface ModuleOptions {
    * @default '.data/hub'
    */
   dir?: string
-
+  /**
+   * The directories to scan for database migrations.
+   * @default ['server/database/migrations']
+   */
+  databaseMigrationsDirs?: string[]
   /**
    * The extra bindings for the project.
    *


### PR DESCRIPTION
Fixes the missing databaseMigrationsDirs type defintion in `src/types/module.ts` file.
