### PR TITLE
docs: clarify nitro cloudflare-durable preset in WebSocket setup

### DIFF
--- a/docs/content/docs/2.features/realtime.md
+++ b/docs/content/docs/2.features/realtime.md
@@ -11,6 +11,7 @@ Enable [Nitro's experimental WebSocket](https://nitro.build/guide/websocket) sup
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   nitro: {
+    preset: 'cloudflare-durable',
     experimental: {
       websocket: true
     }


### PR DESCRIPTION
Fix Realtime & WebSockets docs by adding required cloudflare-durable preset. The hub.workers TypeScript hint says it should automatically set the preset to cloudflare-durable when nitro nitro.experimental.websocket is enabled, but this doesn't actually happen during build.