### PR TITLE
     docs(autorag): remove non-existent model option

### DIFF
--- a/docs/content/docs/2.features/autorag.md
+++ b/docs/content/docs/2.features/autorag.md
@@ -73,10 +73,6 @@ export default defineEventHandler(async () => {
     The input query.
   ::
 
-  ::field{name="model" type="string"}
-    The text-generation model that is used to generate the response for the query. For a list of valid options, check the AutoRAG Generation model Settings. Defaults to the generation model selected in the AutoRAG Settings.
-  ::
-
   ::field{name="rewrite_query" type="boolean"}
     Rewrites the original query into a search optimized query to improve retrieval accuracy. Defaults to `false`.
   ::


### PR DESCRIPTION
Remove the model option from the example in core/docs/content/docs/2.features/autorag.md so the docs match the original Cloudflare Workers types.

```ts
export type AutoRagSearchRequest = {
  query: string;
  filters?: CompoundFilter | ComparisonFilter;
  max_num_results?: number;
  ranking_options?: {
    ranker?: string;
    score_threshold?: number;
  };
  rewrite_query?: boolean;
};

```