### PR TITLE
feat(database): enable interactive mode for migration generation

### DIFF
--- a/cli/commands/database/generate.mjs
+++ b/cli/commands/database/generate.mjs
@@ -38,7 +38,11 @@ export default defineCommand({
     await execa(options)`nuxt prepare`
     await buildDatabaseSchema(join(options.cwd, '.nuxt'), { relativeDir: cwd })
     consola.info('Generating database migrations...')
-    const { stderr } = await execa({ ...options, stdout: 'inherit' })`drizzle-kit generate --config=./.nuxt/hub/database/drizzle.config.ts`
+    const { stderr } = await execa({
+      ...options,
+      stdin: 'inherit',
+      stdout: 'inherit'
+    })`drizzle-kit generate --config=./.nuxt/hub/database/drizzle.config.ts`
     // Drizzle-kit does not exit with an error code when there is an error, so we need to check the stderr
     if (stderr) {
       consola.error(stderr)


### PR DESCRIPTION
## Problem

The `nuxthub database generate` command was not interactive because it didn't have access to `stdin`. When drizzle-kit needed to confirm changes or perform other user interactions during migration generation, it wasn't possible.

<img width="556" height="68" alt="Snímek obrazovky 2025-11-27 v 17 57 34" src="https://github.com/user-attachments/assets/bd1876be-8423-456b-a2a4-e56a57a32190" />

## Solution

- Added `stdin: 'inherit'` to execa options so drizzle-kit can read user input

Users can now interactively respond to drizzle-kit prompts during migration generation.