### PR TITLE
feat(blob): add support for access and improve s3 driver

### DIFF
--- a/docs/content/docs/2.features/0.blob.md
+++ b/docs/content/docs/2.features/0.blob.md
@@ -372,6 +372,9 @@ async function uploadImage (e: Event) {
   ::field{name="options" type="Object"}
     The put options. Any other provided field will be stored in the blob's metadata.
     ::collapsible
+      ::field{name="access" type="'public' | 'private'"}
+        The access level of the blob. Can be `'public'` or `'private'`. Note that only S3 driver supports this option currently.
+      ::
       ::field{name="contentType" type="String"}
         The content type of the blob. If not given, it will be inferred from the Blob or the file extension.
       ::

--- a/playground/server/api/blob/multipart/[action]/[...pathname].ts
+++ b/playground/server/api/blob/multipart/[action]/[...pathname].ts
@@ -2,6 +2,7 @@ import { blob } from 'hub:blob'
 
 export default eventHandler(async (event) => {
   return await blob.handleMultipartUpload(event, {
-    addRandomSuffix: true
+    addRandomSuffix: true,
+    access: 'public'
   })
 })

--- a/src/blob/lib/drivers/cloudflare-r2.ts
+++ b/src/blob/lib/drivers/cloudflare-r2.ts
@@ -86,6 +86,9 @@ export function createDriver(options: CloudflareDriverOptions): BlobDriver<Cloud
 
       const contentType = options?.contentType || (body instanceof Blob ? body.type : undefined) || getContentType(pathname)
 
+      if (options?.access) {
+        console.warn('Setting access level for blob in Cloudflare R2 is not supported, it will be ignored')
+      }
       const r2Object = await bucket.put(pathname, body as any, {
         httpMetadata: {
           contentType

--- a/src/blob/lib/drivers/vercel-blob.ts
+++ b/src/blob/lib/drivers/vercel-blob.ts
@@ -1,7 +1,7 @@
 import { put as vercelPut, del as vercelDel, head as vercelHead, list as vercelList, createMultipartUpload as vercelCreateMultipartUpload, uploadPart as vercelUploadPart, completeMultipartUpload as vercelCompleteMultipartUpload } from '@vercel/blob'
 import { handleUpload, type HandleUploadBody } from '@vercel/blob/client'
 import type { PutBlobResult, ListBlobResultBlob } from '@vercel/blob'
-import { readBody, type H3Event } from 'h3'
+import { createError, readBody, type H3Event } from 'h3'
 import type { BlobDriver, BlobPutBody } from './types'
 import type { BlobListOptions, BlobListResult, BlobMultipartOptions, BlobMultipartUpload, BlobObject, BlobPutOptions, BlobUploadedPart, HandleMPUResponse } from '../../types'
 import { getContentType } from '../utils'
@@ -81,6 +81,12 @@ export function createDriver(options: VercelDriverOptions = {}): BlobDriver<Verc
     async put(pathname: string, body: BlobPutBody, putOptions?: BlobPutOptions): Promise<BlobObject> {
       const contentType = putOptions?.contentType || (body instanceof Blob ? body.type : undefined) || getContentType(pathname)
 
+      if (putOptions?.access === 'private') {
+        throw createError({
+          statusCode: 400,
+          statusMessage: 'Private access is not yet supported for Vercel Blob'
+        })
+      }
       const result = await vercelPut(pathname, body as any, {
         token,
         access: access as 'public',

--- a/src/blob/lib/storage.ts
+++ b/src/blob/lib/storage.ts
@@ -55,7 +55,7 @@ export function createBlobStorage(driver: BlobDriver): BlobStorage {
 
     async put(pathname: string, body: string | ReadableStream<any> | ArrayBuffer | ArrayBufferView | Blob, options: BlobPutOptions = {}) {
       pathname = decodeURIComponent(pathname)
-      const { contentType: optionsContentType, contentLength, addRandomSuffix, prefix, customMetadata } = options
+      const { contentType: optionsContentType, contentLength, addRandomSuffix, prefix, customMetadata, access } = options
       const contentType = optionsContentType || (body as Blob).type || getContentType(pathname)
 
       const { dir, ext, name: filename } = parse(pathname)
@@ -72,7 +72,8 @@ export function createBlobStorage(driver: BlobDriver): BlobStorage {
       return driver.put(pathname, body, {
         contentType,
         contentLength,
-        customMetadata
+        customMetadata,
+        access
       })
     },
 

--- a/src/blob/setup.ts
+++ b/src/blob/setup.ts
@@ -24,7 +24,7 @@ export function resolveBlobConfig(hub: HubConfig, deps: Record<string, string>):
 
   // Otherwise hub.blob is set to true, so we need to resolve the config
   // AWS S3
-  if (process.env.S3_ACCESS_KEY_ID && process.env.S3_SECRET_ACCESS_KEY && process.env.S3_BUCKET && process.env.S3_REGION) {
+  if (process.env.S3_ACCESS_KEY_ID && process.env.S3_SECRET_ACCESS_KEY && (process.env.S3_BUCKET || process.env.S3_ENDPOINT)) {
     if (!deps['aws4fetch']) {
       log.error('Please run `npx nypm i aws4fetch` to use S3')
     }
@@ -32,8 +32,8 @@ export function resolveBlobConfig(hub: HubConfig, deps: Record<string, string>):
       driver: 's3',
       accessKeyId: process.env.S3_ACCESS_KEY_ID,
       secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
-      bucket: process.env.S3_BUCKET,
-      region: process.env.S3_REGION,
+      bucket: process.env.S3_BUCKET || '',
+      region: process.env.S3_REGION || 'auto',
       endpoint: process.env.S3_ENDPOINT
     }) as ResolvedBlobConfig
   }

--- a/src/blob/types/index.ts
+++ b/src/blob/types/index.ts
@@ -107,6 +107,10 @@ export interface BlobListOptions {
 
 export interface BlobPutOptions {
   /**
+   * The access level of the blob.
+   */
+  access?: 'public' | 'private'
+  /**
    * The content type of the blob.
    */
   contentType?: string
@@ -134,6 +138,10 @@ export interface BlobPutOptions {
 }
 
 export interface BlobMultipartOptions {
+  /**
+   * The access level of the blob.
+   */
+  access?: 'public' | 'private'
   /**
    * The content type of the blob.
    */


### PR DESCRIPTION
This pull request introduces support for specifying access levels ('public' or 'private') when uploading blobs, with initial implementation for S3 and partial handling for other drivers. It updates the documentation, types, and driver logic to accommodate this feature, while ensuring backward compatibility and providing clear warnings or errors for unsupported configurations.

**Access Level Support for Blob Uploads**

* Added an `access` field to `BlobPutOptions` and `BlobMultipartOptions` types, allowing users to specify `'public'` or `'private'` access when uploading blobs. [[1]](diffhunk://#diff-3763769477a47090ac9d300001f6fe52371a9c106d5d47302df0fe32b2f5266eR109-R112) [[2]](diffhunk://#diff-3763769477a47090ac9d300001f6fe52371a9c106d5d47302df0fe32b2f5266eR141-R144)
* Updated documentation (`docs/content/docs/2.features/0.blob.md`) to describe the new `access` option, noting that only the S3 driver currently supports it.

**S3 Driver Enhancements**

* Implemented support for the `access` option in the S3 driver: setting `'public'` adds the appropriate ACL header (`x-amz-acl: public-read`) to make the blob public.
* Adjusted S3 driver configuration logic to better handle optional endpoint and region settings, improving compatibility with S3-compatible services. [[1]](diffhunk://#diff-2087d9710331709eca7156c75151c0e4d113c4863fe989c734259794ac81a887L81-R87) [[2]](diffhunk://#diff-efe32e970506825e8f48725724d111105210bd9fb4171d77aba5a20eb1f358faL27-R36)

**Other Driver Handling**

* For Cloudflare R2, added a warning if the `access` option is used, indicating that access level is not supported and will be ignored.
* For Vercel Blob, added an error if `'private'` access is requested, as this is not yet supported.
