### PR TITLE
fix(db): resolve JSON $type<> types in schema

### DIFF
--- a/src/db/lib/build.ts
+++ b/src/db/lib/build.ts
@@ -90,7 +90,7 @@ export async function buildDatabaseSchema(buildDir: string, { relativeDir }: { r
     outDir: join(buildDir, 'hub/db'),
     outExtensions: () => ({
       js: '.mjs',
-      dts: '.d.ts'
+      dts: '.d.mts'
     }),
     alias: {
       'hub:db:schema': entry

--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -216,7 +216,7 @@ declare module 'hub:db' {
    * The database schema object
    * Defined in server/db/schema.ts and server/db/schema/*.ts
    */
-  export * as schema from './db/schema.mjs'
+  export { schema }
   /**
    * The ${driver} database client.
    */


### PR DESCRIPTION
Fixes #710

## Problem

JSON fields with `$type<SomeType>()` return `any` instead of the typed result.

**Root cause**: ts doesn't resolve types from `.d.ts` files for `.mjs` imports. For ESM modules, TypeScript looks for `.d.mts` declaration files.

Additionally, `export * as schema from './db/schema.mjs'` inside a `declare module` block doesn't resolve paths correctly for virtual modules.


## Reproduction

```bash
# Clone repro folder
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-710 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-710

# Install and run
cd nuxthub-710 && pnpm install && pnpm dev

# Check server/api/test.ts - styles field shows as `any`
```

## Verify fix

<details><summary>Video with LSP in action</summary>
<p>



https://github.com/user-attachments/assets/0b4f25a9-ab17-4a00-b2da-4a66b7cc6bfb


</p>
</details> 

```bash
cd repros && git sparse-checkout add nuxthub-710-fixed
cd nuxthub-710-fixed && pnpm install && pnpm dev

# Check server/api/test.ts - styles field now shows as `Style[]`
```

The `-fixed` folder includes a pnpm patch with both changes.