### PR TITLE
fix(db): pass mode to drizzle for mysql

### DIFF
--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -206,7 +206,7 @@ async function generateDatabaseSchema(nuxt: Nuxt, hub: ResolvedHubConfig) {
 }
 
 async function setupDatabaseClient(nuxt: Nuxt, hub: ResolvedHubConfig) {
-  const { driver, connection } = hub.db as ResolvedDatabaseConfig
+  const { dialect, driver, connection, mode } = hub.db as ResolvedDatabaseConfig
 
   // For types, d1-http uses sqlite-proxy
   const driverForTypes = driver === 'd1-http' ? 'sqlite-proxy' : driver
@@ -236,10 +236,11 @@ declare module 'hub:db' {
   // Setup Drizzle ORM
 
   // Generate simplified drizzle() implementation
+  const modeOption = dialect === 'mysql' ? `, mode: '${mode || 'default'}'` : ''
   let drizzleOrmContent = `import { drizzle } from 'drizzle-orm/${driver}'
 import * as schema from './db/schema.mjs'
 
-const db = drizzle({ connection: ${JSON.stringify(connection)}, schema })
+const db = drizzle({ connection: ${JSON.stringify(connection)}, schema${modeOption} })
 export { db, schema }
 `
 
@@ -368,7 +369,7 @@ function getDb() {
   if (!_db) {
     const hyperdrive = process.env.${bindingName} || globalThis.__env__?.${bindingName} || globalThis.${bindingName}
     if (!hyperdrive) throw new Error('${bindingName} binding not found')
-    _db = drizzle({ connection: hyperdrive.connectionString, schema })
+    _db = drizzle({ connection: hyperdrive.connectionString, schema${modeOption} })
   }
   return _db
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -179,6 +179,14 @@ export type DatabaseConfig = {
    * @default true
    */
   applyMigrationsDuringBuild?: boolean
+  /**
+   * MySQL mode for Drizzle ORM relational queries.
+   * Only applicable when dialect is 'mysql'.
+   *
+   * @default 'default'
+   * @see https://orm.drizzle.team/docs/rqb#modes
+   */
+  mode?: 'default' | 'planetscale'
 }
 
 export type ResolvedDatabaseConfig = DatabaseConfig & {


### PR DESCRIPTION
Fixes #727

## Problem

MySQL drizzle requires `mode: 'default' | 'planetscale'` when using schema with relational queries. The config option was being ignored.

**Generated code before:**
```js
const db = drizzle({ connection: {...}, schema })
```

**Generated code after:**
```js
const db = drizzle({ connection: {...}, schema, mode: 'default' })
```

## Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-727 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-727
cd nuxthub-727 && MYSQL_URL="mysql://test:test@localhost/test" pnpm install && MYSQL_URL="mysql://test:test@localhost/test" pnpm nuxi prepare

# Check .nuxt/hub/db.mjs - missing mode parameter
cat .nuxt/hub/db.mjs
```

## Verify fix

```bash
cd repros && git sparse-checkout add nuxthub-727-fixed
cd nuxthub-727-fixed && MYSQL_URL="mysql://test:test@localhost/test" pnpm install && MYSQL_URL="mysql://test:test@localhost/test" pnpm nuxi prepare

# Check .nuxt/hub/db.mjs - now includes mode: 'default'
cat .nuxt/hub/db.mjs
```

The `-fixed` folder includes a pnpm patch with the fix.


Other solutions:
- We could create a discriminated type so that the new type only appears for `mysql`, but I think this might be overcomplicating things.
- Alternatively, we could add a new dialect called `planetscale`, which is an alias for `mysql` with the required mode. However, this goes against the Drizzle config.