### PR TITLE
docs: auto-generate wrangler bindings from config

### DIFF
--- a/docs/content/docs/1.getting-started/3.deploy.md
+++ b/docs/content/docs/1.getting-started/3.deploy.md
@@ -24,49 +24,68 @@ You can deploy your project on your own Cloudflare account, you need to create t
 You only need to create these resources if you have explicitly enabled them in the `hub` config.
 ::
 
-Then, create a [Cloudflare Workers project](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create) and link your GitHub or GitLab repository.
+### Configure Bindings
 
-Once your project is created, open the `Settings` tab and set:
-- Bindings
-  - KV namespace: `KV` and select your KV namespace created
-  - KV namespace: `CACHE` and select your KV namespace for caching created
-  - R2 bucket: `BLOB` and select your R2 bucket created
-  - D1 database: `DB` and select your D1 database created
+NuxtHub auto-generates the `wrangler.json` file at build time when you provide resource IDs in your config. No manual `wrangler.jsonc` is required.
 
-Then make sure to create the following `wrangler.jsonc` file in the root of your project:
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  hub: {
+    // D1 database
+    db: {
+      dialect: 'sqlite',
+      driver: 'd1',
+      connection: { databaseId: '<database-id>' }
+    },
+    // KV namespace (binding defaults to 'KV')
+    kv: {
+      driver: 'cloudflare-kv-binding',
+      namespaceId: '<kv-namespace-id>'
+    },
+    // Cache KV namespace (binding defaults to 'CACHE')
+    cache: {
+      driver: 'cloudflare-kv-binding',
+      namespaceId: '<cache-namespace-id>'
+    },
+    // R2 bucket (binding defaults to 'BLOB')
+    blob: {
+      driver: 'cloudflare-r2',
+      bucketName: '<bucket-name>'
+    }
+  }
+})
+```
+
+::tip
+See a working example at [onmax/repros/nuxthub-716](https://github.com/onmax/repros/tree/main/nuxthub-716) — deployed without a `wrangler.toml` file.
+::
+
+### Deploy
+
+Create a [Cloudflare Workers project](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create) and link your GitHub or GitLab repository. NuxtHub auto-configures bindings from your `nuxt.config.ts` during build.
+
+::collapsible{title="Alternative: Manual wrangler.jsonc"}
+You can also create a `wrangler.jsonc` file manually in the root of your project:
 
 ```jsonc [wrangler.jsonc]
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  // if hub.db is enabled
+  // D1 database
   "d1_databases": [
-    {
-        "binding": "DB",
-        "database_name": "<database-name>",
-        "database_id": "<database-id>"
-      }
-    ],
-  // if hub.blob is enabled
-  "r2_buckets": [
-    {
-        "binding": "BLOB",
-        "bucket_name": "<bucket-name>"
-    }
+    { "binding": "DB", "database_name": "<name>", "database_id": "<id>" }
   ],
+  // R2 bucket
+  "r2_buckets": [
+    { "binding": "BLOB", "bucket_name": "<bucket-name>" }
+  ],
+  // KV namespaces
   "kv_namespaces": [
-    // if hub.kv is enabled
-    {
-      "binding": "KV",
-      "id": "<kv-namespace-id>"
-    },
-    // if hub.cache is enabled
-    {
-      "binding": "CACHE",
-      "id": "<cache-namespace-id>"
-    }
+    { "binding": "KV", "id": "<kv-namespace-id>" },
+    { "binding": "CACHE", "id": "<cache-namespace-id>" }
   ]
 }
 ```
+::
 
 ### Environments
 

--- a/docs/content/docs/2.database/1.index.md
+++ b/docs/content/docs/2.database/1.index.md
@@ -38,6 +38,9 @@ Install Drizzle ORM, Drizzle Kit, and the appropriate driver(s) for the database
     - Uses `libsql` driver for [Turso](https://turso.tech) if you set `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` environment variables.
     - Uses `libsql` locally with file at `.data/db/sqlite.db` if no environment variables are set.
     ::
+    ::tip{to="/docs/getting-started/deploy#cloudflare"}
+    For Cloudflare D1, configure the database ID in your `nuxt.config.ts` and NuxtHub auto-generates the wrangler bindings.
+    ::
   :::
 ::
 

--- a/docs/content/docs/3.blob/1.index.md
+++ b/docs/content/docs/3.blob/1.index.md
@@ -90,27 +90,25 @@ By default, if NuxtHub cannot detect a driver, files are stored locally in the `
 
   :::tabs-item{label="Cloudflare R2" icon="i-simple-icons-cloudflare"}
 
-    When deploying to Cloudflare, it automatically configures [Cloudflare R2](https://developers.cloudflare.com/r2/).
+    When deploying to Cloudflare, configure [Cloudflare R2](https://developers.cloudflare.com/r2/) by providing the bucket name. NuxtHub auto-generates the wrangler bindings at build time.
 
-    Add a `BLOB` binding to a [Cloudflare R2](https://developers.cloudflare.com/r2/) bucket in your `wrangler.jsonc` config.
-
-    ```json [wrangler.jsonc]
-    {
-      "$schema": "node_modules/wrangler/config-schema.json",
-      // ...
-      "r2_buckets": [
-        {
-          "binding": "BLOB",
-          "bucket_name": "<bucket_name>"
+    ```ts [nuxt.config.ts]
+    export default defineNuxtConfig({
+      hub: {
+        blob: {
+          driver: 'cloudflare-r2',
+          bucketName: '<bucket-name>'
         }
-      ]
-    }
+      }
+    })
     ```
 
-    Learn more about adding bindings on [Cloudflare's documentation](https://developers.cloudflare.com/r2/api/workers/workers-api-usage/).
+    ::callout{to="https://developers.cloudflare.com/r2/api/workers/workers-api-usage/"}
+    Learn more about R2 bindings on Cloudflare's documentation.
+    ::
 
-    ::tip
-      To use Cloudflare R2 without hosting on Cloudflare Workers, use the [Cloudflare R2 via S3 API](https://developers.cloudflare.com/r2/api/s3/api/).
+    ::note
+    To use Cloudflare R2 without hosting on Cloudflare Workers, use the [Cloudflare R2 via S3 API](https://developers.cloudflare.com/r2/api/s3/api/).
     ::
 
   :::

--- a/docs/content/docs/4.kv/1.index.md
+++ b/docs/content/docs/4.kv/1.index.md
@@ -56,24 +56,22 @@ When building the Nuxt app, NuxtHub automatically configures the key-value stora
 
   :::tabs-item{label="Cloudflare KV" icon="i-simple-icons-cloudflare"}
 
-    When deploying to Cloudflare, it automatically configures [Cloudflare Workers KV](https://developers.cloudflare.com/kv/).
+    When deploying to Cloudflare, configure [Cloudflare Workers KV](https://developers.cloudflare.com/kv/) by providing the namespace ID. NuxtHub auto-generates the wrangler bindings at build time.
 
-    Add a `KV` binding to a [Cloudflare Workers KV](https://developers.cloudflare.com/kv/) namespace in your `wrangler.jsonc` config.
-
-    ```jsonc [wrangler.jsonc]
-    {
-      "$schema": "node_modules/wrangler/config-schema.json",
-      // ...
-      "kv_namespaces": [
-        {
-          "binding": "KV",
-          "id": "<id>"
+    ```ts [nuxt.config.ts]
+    export default defineNuxtConfig({
+      hub: {
+        kv: {
+          driver: 'cloudflare-kv-binding',
+          namespaceId: '<kv-namespace-id>'
         }
-      ]
-    }
+      }
+    })
     ```
 
-    Learn more about adding bindings on [Cloudflare's documentation](https://developers.cloudflare.com/kv/concepts/kv-bindings/#access-kv-from-workers).
+    ::callout{to="https://developers.cloudflare.com/kv/concepts/kv-bindings/"}
+    Learn more about KV bindings on Cloudflare's documentation.
+    ::
 
   :::
 

--- a/docs/content/docs/5.cache/1.index.md
+++ b/docs/content/docs/5.cache/1.index.md
@@ -29,24 +29,22 @@ NuxtHub automatically configures the cache storage driver based on your hosting 
   :::
 
   :::tabs-item{label="Cloudflare" icon="i-simple-icons-cloudflare" class="p-4"}
-    When deploying to Cloudflare, it automatically configures [Cloudflare Workers KV](https://developers.cloudflare.com/kv/).
+    When deploying to Cloudflare, configure [Cloudflare Workers KV](https://developers.cloudflare.com/kv/) for caching by providing the namespace ID. NuxtHub auto-generates the wrangler bindings at build time.
 
-    Add a `CACHE` binding to a [Cloudflare Workers KV](https://developers.cloudflare.com/kv/) namespace in your `wrangler.jsonc` config.
-
-    ```json [wrangler.jsonc]
-    {
-      "$schema": "node_modules/wrangler/config-schema.json",
-      // ...
-      "kv_namespaces": [
-        {
-          "binding": "CACHE",
-          "id": "<id>"
+    ```ts [nuxt.config.ts]
+    export default defineNuxtConfig({
+      hub: {
+        cache: {
+          driver: 'cloudflare-kv-binding',
+          namespaceId: '<cache-namespace-id>'
         }
-      ]
-    }
+      }
+    })
     ```
 
-    Learn more about adding bindings on [Cloudflare's documentation](https://developers.cloudflare.com/kv/concepts/kv-bindings/#access-kv-from-workers).
+    ::callout{to="https://developers.cloudflare.com/kv/concepts/kv-bindings/"}
+    Learn more about KV bindings on Cloudflare's documentation.
+    ::
   :::
 
   :::tabs-item{label="Other" icon="i-simple-icons-nodedotjs" class="p-4"}


### PR DESCRIPTION
Documents auto-generate wrangler bindings from nuxt.config.

## Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-716 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-716
cd nuxthub-716
pnpm install
pnpm build
```

Live demo of the automatic-wrangler: https://onmax-repros-nuxthub-716.maximogarciamtnez.workers.dev