### PR TITLE
fix(db): add ts declaration for `hub:db:schema`

### DIFF
--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -243,11 +243,10 @@ async function generateDatabaseSchema(nuxt: Nuxt, hub: ResolvedHubConfig) {
   nuxt.options.alias ||= {}
   nuxt.options.alias['hub:db:schema'] = join(nuxt.options.buildDir, 'hub/db/schema.mjs')
 
-  const schemaTypePath = join(nuxt.options.buildDir, 'hub/db/schema.d.mts')
   addTypeTemplate({
     filename: 'hub/db/schema.d.ts',
     getContents: () => `declare module 'hub:db:schema' {
-  export * from '${schemaTypePath}'
+  export * from '#build/hub/db/schema.mjs'
 }`
   }, { nitro: true, nuxt: true })
 }


### PR DESCRIPTION
Adds a `hub/db/schema.d.ts` type template that declares the `hub:db:schema` module and re-exports types from the generated `#build/hub/db/schema.mjs` file, ensuring proper type inference when importing the schema