### PR TITLE
docs: clarify D1 migrations not run during build

### DIFF
--- a/docs/content/docs/2.database/4.migrations.md
+++ b/docs/content/docs/2.database/4.migrations.md
@@ -69,6 +69,10 @@ Migrations are automatically applied when you:
 
 Applied migrations are tracked in the `_hub_migrations` database table.
 
+::warning{to="/docs/getting-started/deploy#cloudflare"}
+For Cloudflare D1, migrations cannot run during build since there is no database connection in CI. Run `npx nuxt db migrate` locally or set up a CI step to apply migrations before deployment.
+::
+
 ::note
 To disable automatic migrations during `nuxt build`, you can set the `applyMigrationsDuringBuild` option to `false`:
 


### PR DESCRIPTION
Docs said migrations run during build, but D1 forces `applyMigrationsDuringBuild: false` since there's no DB connection in CI.

Added warning callout to clarify users must run `npx nuxt db migrate` manually for D1.