### PR TITLE
docs: clean up prose tabs spacing

### DIFF
--- a/docs/app/app.config.ts
+++ b/docs/app/app.config.ts
@@ -25,11 +25,11 @@ export default defineAppConfig({
       },
       tabs: {
         slots: {
-          root: 'rounded border border-default'
+          root: 'rounded border border-default gap-0'
         }
       },
       tabsItem: {
-        base: 'p-4 *:my-3 pt-2 text-sm'
+        base: 'p-4'
       }
     }
   },


### PR DESCRIPTION
Opinionated change for cleaner UI with better spacing in prose tabs.

|  | Before | After |
|---|--------|-------|
| Hero | <img width="1069" height="775" alt="image" src="https://github.com/user-attachments/assets/ec333935-18ac-4250-a758-75557004d415" /> | <img width="1037" height="688" alt="image" src="https://github.com/user-attachments/assets/bd111d84-552a-4bd1-93f9-4d0d14795bb3" /> |
| Docs | <img width="1232" height="561" alt="image" src="https://github.com/user-attachments/assets/576fae35-a38c-4704-b607-dc5543d4387f" /> |  <img width="976" height="504" alt="image" src="https://github.com/user-attachments/assets/5f440b80-65ac-4b49-8d5a-0d8c5104358b" /> |