### PR TITLE
fix: handle nitro-cloudflare-dev Promise bindings

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -50,6 +50,12 @@ export default defineBuildConfig({
       input: 'src/cache/runtime/',
       outDir: 'dist/cache/runtime',
       builder: 'mkdist'
+    },
+    // Remote (cloudflare dev bindings)
+    {
+      input: 'src/remote/runtime/',
+      outDir: 'dist/remote/runtime',
+      builder: 'mkdist'
     }
   ]
 })

--- a/src/db/runtime/plugins/migrations.dev.ts
+++ b/src/db/runtime/plugins/migrations.dev.ts
@@ -1,7 +1,5 @@
 import type { ResolvedHubConfig } from '../../../types'
 import { applyDatabaseMigrations, applyDatabaseQueries } from '../../lib/migrations'
-// @ts-expect-error - Generated at runtime
-import { db } from 'hub:db'
 import { defineNitroPlugin, useRuntimeConfig } from '#imports'
 
 export default defineNitroPlugin(async () => {
@@ -9,6 +7,21 @@ export default defineNitroPlugin(async () => {
 
   const hub = useRuntimeConfig().hub as ResolvedHubConfig
   if (!hub.db) return
+
+  let db
+  try {
+    // @ts-expect-error - Generated at runtime
+    const module = await import('hub:db')
+    db = module.db
+  } catch (error: any) {
+    console.error('[nuxt:hub] Failed to import hub:db module')
+    console.error('[nuxt:hub] This may happen if database bindings are not ready yet.')
+    if (hub._remote) {
+      console.error('[nuxt:hub] In remote mode, ensure wrangler is logged in and binding IDs are correct.')
+    }
+    console.error('[nuxt:hub] Error:', error.message || error)
+    return
+  }
 
   await applyDatabaseMigrations(hub, db)
   await applyDatabaseQueries(hub, db)

--- a/src/remote/runtime/plugin.dev.ts
+++ b/src/remote/runtime/plugin.dev.ts
@@ -1,0 +1,97 @@
+import type { NitroAppPlugin } from 'nitropack'
+import type { GetPlatformProxyOptions } from 'wrangler'
+// @ts-expect-error - virtual import
+import { useRuntimeConfig } from '#imports'
+
+// Track initialization state to provide helpful errors
+let _initError: Error | null = null
+
+const _proxy = _getPlatformProxy()
+  .catch((error) => {
+    const isAuthError = error.message?.includes('login') || error.message?.includes('auth')
+    const isNetworkError = error.message?.includes('ENOTFOUND') || error.message?.includes('network')
+
+    console.error('[nuxt:hub] Failed to initialize remote Cloudflare bindings')
+    console.error('[nuxt:hub] Error:', error.message || error)
+
+    if (isAuthError) {
+      console.error('[nuxt:hub] This appears to be an authentication issue.')
+      console.error('[nuxt:hub] Ensure you are logged into wrangler: `npx wrangler login`')
+    } else if (isNetworkError) {
+      console.error('[nuxt:hub] This appears to be a network issue.')
+      console.error('[nuxt:hub] Check your internet connection and try again.')
+    } else {
+      console.error('[nuxt:hub] Verify your binding IDs are correct in nuxt.config')
+    }
+
+    _initError = new Error(`[nuxt:hub] Cannot start in remote mode: ${error.message || error}`)
+    throw _initError
+  })
+  .then((proxy) => {
+    // Only set __env__ once proxy is successfully resolved
+    ;(globalThis as any).__env__ = proxy.env
+    return proxy
+  })
+
+// Create a proxy that throws helpful errors when accessed before initialization
+// or when initialization failed
+;(globalThis as any).__env__ = new Proxy({}, {
+  get(_, prop) {
+    if (_initError) {
+      throw _initError
+    }
+    throw new Error(`[nuxt:hub] Cloudflare bindings not ready. The "${String(prop)}" binding was accessed before initialization completed.`)
+  }
+})
+
+export default <NitroAppPlugin> function (nitroApp) {
+  nitroApp.hooks.hook('request', async (event) => {
+    const proxy = await _proxy
+
+    event.context.cf = proxy.cf
+    event.context.waitUntil = proxy.ctx.waitUntil.bind(proxy.ctx)
+
+    event.context.cloudflare = {
+      ...event.context.cloudflare,
+      env: proxy.env,
+      context: proxy.ctx
+    }
+
+    ;(event.node.req as any).__unenv__ = {
+      ...(event.node.req as any).__unenv__,
+      waitUntil: event.context.waitUntil
+    }
+  })
+
+  // Ensure our hook runs first
+  // @ts-expect-error - accessing internal hooks
+  nitroApp.hooks._hooks.request?.unshift(nitroApp.hooks._hooks.request?.pop())
+
+  nitroApp.hooks.hook('close', () => {
+    return _proxy?.then(proxy => proxy.dispose())
+  })
+}
+
+async function _getPlatformProxy() {
+  const _pkg = 'wrangler'
+  const { getPlatformProxy } = (await import(_pkg).catch(() => {
+    throw new Error('[nuxt:hub] Package `wrangler` not found. Please install it with: `npx nypm@latest add -D wrangler`')
+  })) as typeof import('wrangler')
+
+  const runtimeConfig = useRuntimeConfig() as {
+    hub: {
+      _remote?: { configPath: string, persistDir: string }
+    }
+  }
+
+  if (!runtimeConfig.hub._remote) {
+    throw new Error('[nuxt:hub] Remote configuration not found. This plugin should only be loaded when hub.remote is true.')
+  }
+
+  const proxyOptions: GetPlatformProxyOptions = {
+    configPath: runtimeConfig.hub._remote.configPath,
+    persist: { path: runtimeConfig.hub._remote.persistDir }
+  }
+
+  return await getPlatformProxy(proxyOptions)
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -11,6 +11,13 @@ export interface HubConfig {
   kv: boolean | KVConfig
   dir: string
   hosting: string
+  /**
+   * Use remote Cloudflare bindings during local development.
+   * Connects to your deployed Cloudflare D1/KV/R2 instead of local emulation.
+   * Requires binding IDs (databaseId, namespaceId, bucketName) in config.
+   * @default false
+   */
+  remote: boolean
 }
 
 export interface ResolvedHubConfig extends HubConfig {
@@ -19,6 +26,8 @@ export interface ResolvedHubConfig extends HubConfig {
   db: ResolvedDatabaseConfig | false
   kv: ResolvedKVConfig | false
   dir: string
+  /** Internal: remote wrangler config path (set when hub.remote is true) */
+  _remote?: { configPath: string, persistDir: string }
 }
 
 export interface ModuleRuntimeConfig {
@@ -68,6 +77,13 @@ export interface ModuleOptions {
    * This is automatically determined using the NITRO_PRESET or the detected provider during the CI/CD.
    */
   hosting?: string
+  /**
+   * Use remote Cloudflare bindings during local development.
+   * Connects to your deployed Cloudflare D1/KV/R2 instead of local emulation.
+   * Requires binding IDs (databaseId, namespaceId, bucketName) in config.
+   * @default false
+   */
+  remote?: boolean
 }
 
 // Blob driver configurations - extend from driver option types

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,13 @@
 import type { Nuxt } from '@nuxt/schema'
 import { logger, createResolver } from '@nuxt/kit'
+import type { HubConfig } from '@nuxthub/core'
 
 const log = logger.withTag('nuxt:hub')
+
+/** Check if running in dev mode with remote Cloudflare bindings enabled */
+export function isRemoteDev(nuxt: Nuxt, hub: HubConfig): boolean {
+  return nuxt.options.dev && hub.remote
+}
 
 export function logWhenReady(nuxt: Nuxt, message: string, type: 'info' | 'warn' | 'error' = 'info') {
   if (nuxt.options._prepare) {


### PR DESCRIPTION
## Superseded

This PR has been superseded by:
- #787 - auto-remote-bindings feature (better DX: auto-enables when binding IDs present)
- #788 - dynamic import bug fix for migrations plugin