### PR TITLE
fix(db): generate schema types during nuxt prepare

### DIFF
--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -234,11 +234,9 @@ async function generateDatabaseSchema(nuxt: Nuxt, hub: ResolvedHubConfig) {
     getContents: () => `${schemaPaths.map(path => `export * from '${path}'`).join('\n')}`,
     write: true
   })
-  if (!nuxt.options._prepare) {
-    nuxt.hooks.hookOnce('app:templatesGenerated', async () => {
-      await buildDatabaseSchema(nuxt.options.buildDir, { relativeDir: nuxt.options.rootDir })
-    })
-  }
+  nuxt.hooks.hookOnce('app:templatesGenerated', async () => {
+    await buildDatabaseSchema(nuxt.options.buildDir, { relativeDir: nuxt.options.rootDir })
+  })
 
   nuxt.options.alias ||= {}
   nuxt.options.alias['hub:db:schema'] = join(nuxt.options.buildDir, 'hub/db/schema.mjs')


### PR DESCRIPTION
Fixes #755

## Problem

`nuxt prepare` does not generate `.nuxt/hub/db/schema.mjs` and `schema.d.mts`. Breaks CI typecheck on clean `.nuxt`.

The `!nuxt.options._prepare` guard was added in #693 following a pattern of skipping expensive work during prepare. However, `buildDatabaseSchema()` only compiles TypeScript schema files to JavaScript via tsdowm; a pure compilation step with no side effects. Since types depend on this compiled output, skipping it during prepare breaks typecheck workflows

## Reproduce bug

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-755 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-755
cd nuxthub-755 && pnpm i && rm -rf .nuxt && pnpm prepare
ls .nuxt/hub/db/  # schema.mjs missing
```

## Verify fix

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-755 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-755-fixed
cd nuxthub-755-fixed && pnpm i && rm -rf .nuxt && pnpm prepare
ls .nuxt/hub/db/  # schema.mjs exists
```

The `-fixed` folder includes a pnpm patch with the fix.