### PR TITLE
fix(cli): handle D1 driver in CLI commands

### DIFF
--- a/cli/commands/db/drop-all.mjs
+++ b/cli/commands/db/drop-all.mjs
@@ -73,8 +73,8 @@ export default defineCommand({
     const hubConfig = JSON.parse(await readFile(join(cwd, '.nuxt/hub/db/config.json'), 'utf-8'))
     const dialect = hubConfig.db.dialect
     consola.info(`Database: \`${dialect}\` with \`${hubConfig.db.driver}\` driver`)
-    const url = hubConfig.db.connection.uri || hubConfig.db.connection.url
-    consola.debug(`Database connection: \`${url}\``)
+    const url = hubConfig.db.connection?.uri || hubConfig.db.connection?.url
+    if (url) consola.debug(`Database connection: \`${url}\``)
 
     const hubDir = join(cwd, hubConfig.dir)
     const db = await createDrizzleClient(hubConfig.db, hubDir)

--- a/cli/commands/db/drop.mjs
+++ b/cli/commands/db/drop.mjs
@@ -46,8 +46,8 @@ export default defineCommand({
     })`nuxt prepare`
     const hubConfig = JSON.parse(await readFile(join(cwd, '.nuxt/hub/db/config.json'), 'utf-8'))
     consola.info(`Database: \`${hubConfig.db.dialect}\` with \`${hubConfig.db.driver}\` driver`)
-    const url = hubConfig.db.connection.uri || hubConfig.db.connection.url
-    consola.debug(`Database connection: \`${url}\``)
+    const url = hubConfig.db.connection?.uri || hubConfig.db.connection?.url
+    if (url) consola.debug(`Database connection: \`${url}\``)
     const hubDir = join(cwd, hubConfig.dir)
     const db = await createDrizzleClient(hubConfig.db, hubDir)
     const execute = hubConfig.db.dialect === 'sqlite' ? 'run' : 'execute'

--- a/cli/commands/db/mark-as-migrated.mjs
+++ b/cli/commands/db/mark-as-migrated.mjs
@@ -47,8 +47,8 @@ export default defineCommand({
     const hubConfig = JSON.parse(await readFile(join(cwd, '.nuxt/hub/db/config.json'), 'utf-8'))
     const dialect = hubConfig.db.dialect
     consola.info(`Database: \`${dialect}\` with \`${hubConfig.db.driver}\` driver`)
-    const url = hubConfig.db.connection.uri || hubConfig.db.connection.url
-    consola.debug(`Database connection: \`${url}\``)
+    const url = hubConfig.db.connection?.uri || hubConfig.db.connection?.url
+    if (url) consola.debug(`Database connection: \`${url}\``)
     const localMigrations = await getDatabaseMigrationFiles(hubConfig)
     if (localMigrations.length === 0) {
       consola.info('No local migrations found.')

--- a/cli/commands/db/migrate.mjs
+++ b/cli/commands/db/migrate.mjs
@@ -41,8 +41,8 @@ export default defineCommand({
     consola.info('Applying database migrations...')
     const hubConfig = JSON.parse(await readFile(join(cwd, '.nuxt/hub/db/config.json'), 'utf-8'))
     consola.info(`Database: \`${hubConfig.db.dialect}\` with \`${hubConfig.db.driver}\` driver`)
-    const url = hubConfig.db.connection.uri || hubConfig.db.connection.url
-    consola.debug(`Database connection: \`${url}\``)
+    const url = hubConfig.db.connection?.uri || hubConfig.db.connection?.url
+    if (url) consola.debug(`Database connection: \`${url}\``)
     const hubDir = join(cwd, hubConfig.dir)
     const db = await createDrizzleClient(hubConfig.db, hubDir)
     const migrationsApplied = await applyDatabaseMigrations(hubConfig, db)

--- a/cli/commands/db/sql.mjs
+++ b/cli/commands/db/sql.mjs
@@ -48,8 +48,8 @@ export default defineCommand({
     const hubConfig = JSON.parse(await readFile(join(cwd, '.nuxt/hub/db/config.json'), 'utf-8'))
     const dialect = hubConfig.db.dialect
     consola.info(`Database: \`${dialect}\` with \`${hubConfig.db.driver}\` driver`)
-    const url = hubConfig.db.connection.uri || hubConfig.db.connection.url
-    consola.debug(`Database connection: \`${url}\``)
+    const url = hubConfig.db.connection?.uri || hubConfig.db.connection?.url
+    if (url) consola.debug(`Database connection: \`${url}\``)
     const hubDir = join(cwd, hubConfig.dir)
     const db = await createDrizzleClient(hubConfig.db, hubDir)
 

--- a/src/db/lib/client.ts
+++ b/src/db/lib/client.ts
@@ -2,6 +2,30 @@ import { mkdir } from 'node:fs/promises'
 import { join } from 'pathe'
 import type { ResolvedDatabaseConfig } from '@nuxthub/core'
 
+async function createD1HttpClient(accountId: string, databaseId: string, apiToken: string, casing?: string) {
+  const d1HttpDriver = async (sql: string, params: unknown[], method: string) => {
+    if (method === 'values') method = 'all'
+    const response = await fetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/db/${databaseId}/raw`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sql, params })
+    })
+    const data = await response.json() as { errors?: unknown[], success?: boolean, result?: { success?: boolean, results?: { rows?: unknown[] } }[] }
+    if (data.errors?.length || !data.success) {
+      throw new Error(`D1 HTTP error: ${JSON.stringify(data)}`)
+    }
+    const queryResult = data.result?.[0]
+    if (!queryResult?.success) {
+      throw new Error(`D1 HTTP error: ${JSON.stringify(data)}`)
+    }
+    const rows = queryResult.results?.rows || []
+    if (method === 'get') return { rows: rows.length ? rows[0] : [] }
+    return { rows }
+  }
+  const { drizzle } = await import('drizzle-orm/sqlite-proxy')
+  return drizzle(d1HttpDriver, { casing })
+}
+
 /**
  * Creates a Drizzle client for the given configuration
  */
@@ -10,7 +34,16 @@ export async function createDrizzleClient(config: ResolvedDatabaseConfig, hubDir
   let client
 
   let pkg = ''
-  if (driver === 'postgres-js') {
+  if (driver === 'd1' || driver === 'd1-http') {
+    // Get credentials from config or env vars
+    const accountId = connection?.accountId || process.env.NUXT_HUB_CLOUDFLARE_ACCOUNT_ID
+    const databaseId = connection?.databaseId || process.env.NUXT_HUB_CLOUDFLARE_DATABASE_ID
+    const apiToken = connection?.apiToken || process.env.NUXT_HUB_CLOUDFLARE_API_TOKEN
+    if (!accountId || !databaseId || !apiToken) {
+      throw new Error('D1 CLI commands require Cloudflare API credentials. Set NUXT_HUB_CLOUDFLARE_ACCOUNT_ID, NUXT_HUB_CLOUDFLARE_DATABASE_ID, and NUXT_HUB_CLOUDFLARE_API_TOKEN, or use `npx wrangler d1 migrations apply <DATABASE_NAME>` instead.')
+    }
+    return createD1HttpClient(accountId, databaseId, apiToken, casing)
+  } else if (driver === 'postgres-js') {
     const clientPkg = 'postgres'
     const { default: postgres } = await import(clientPkg)
     client = postgres(connection.url, {


### PR DESCRIPTION
Fixes #707

## Problem

`nuxt db migrate` crashes with `Cannot read properties of undefined (reading 'uri')` when using D1 driver.

## Solution

Auto-detect `NUXT_HUB_CLOUDFLARE_*` env vars for D1 CLI commands. If credentials found, use d1-http. If not, show helpful error with wrangler alternative.

## Reproduce bug

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-707 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-707
cd nuxthub-707 && pnpm i && pnpm prepare && pnpm nuxt db migrate
# ERROR  Cannot read properties of undefined (reading 'uri')
```

## Verify fix

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-707 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-707-fixed
cd nuxthub-707-fixed && pnpm i && pnpm nuxt db migrate
# ERROR  D1 CLI commands require Cloudflare API credentials. Set NUXT_HUB_CLOUDFLARE_ACCOUNT_ID...
```