### PR TITLE
fix: detect static nitro presets

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -27,8 +27,10 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {},
   async setup(options, nuxt) {
-    // Cannot be used with `nuxt generate`
-    if (nuxt.options.nitro.static || (nuxt.options as any)._generate) {
+    // Cannot be used with `nuxt generate` or static presets
+    const preset = (process.env.NITRO_PRESET || nuxt.options.nitro.preset || '').toString().toLowerCase()
+    const isStaticPreset = preset === 'static' || preset.endsWith('-static') || preset.endsWith('_static')
+    if (nuxt.options.nitro.static || (nuxt.options as any)._generate || isStaticPreset) {
       log.error('NuxtHub is not compatible with `nuxt generate` as it needs a server to run.')
       log.info('To pre-render all pages: `https://hub.nuxt.com/docs/recipes/pre-rendering#pre-render-all-pages`')
       return process.exit(1)


### PR DESCRIPTION
Fixes #754

`nitro.preset: 'static'` bypasses NuxtHub's static check. Build proceeds instead of failing with clear error.


## Reproduce bug
```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/hub-754 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set hub-754
cd hub-754 && pnpm i && pnpm build
```

## Verify fix
```bash
git sparse-checkout add hub-754-fixed
cd ../hub-754-fixed && pnpm i && pnpm build
```