### PR TITLE
fix(blob): validate multipart upload body

### DIFF
--- a/docs/content/docs/3.blob/2.upload.md
+++ b/docs/content/docs/3.blob/2.upload.md
@@ -191,16 +191,32 @@ For large files (typically > 10MB), use multipart uploads to split the file into
 
 A server function to handle multipart upload requests. It handles creating, uploading parts, completing, and aborting multipart uploads.
 
-```ts [server/api/files/multipart/[action]/[...pathname].ts]
-import { blob } from 'hub:blob'
+The route pattern depends on your blob driver:
 
-export default eventHandler(async (event) => {
-  return blob.handleMultipartUpload(event)
-})
-```
+::tabs{sync="blob-provider"}
+  :::tabs-item{label="R2/S3/FS" icon="i-lucide-hard-drive"}
+  The route must include `[action]` and `[...pathname]` params. The `action` param handles the multipart operations (`create`, `upload`, `complete`, `abort`).
 
-::important
-Make sure your route includes `[action]` and `[...pathname]` params. The `action` param handles the different multipart operations (`create`, `upload`, `complete`, `abort`).
+  ```ts [server/api/files/multipart/[action]/[...pathname].ts]
+  import { blob } from 'hub:blob'
+
+  export default eventHandler(async (event) => {
+    return blob.handleMultipartUpload(event)
+  })
+  ```
+  :::
+
+  :::tabs-item{label="Vercel Blob" icon="i-simple-icons-vercel"}
+  Use `[...pathname]` only. Vercel Blob uses its own client SDK protocol and does not require the `[action]` parameter.
+
+  ```ts [server/api/files/multipart/[...pathname].ts]
+  import { blob } from 'hub:blob'
+
+  export default eventHandler(async (event) => {
+    return blob.handleMultipartUpload(event)
+  })
+  ```
+  :::
 ::
 
 #### Params
@@ -333,18 +349,20 @@ When using the **Vercel Blob** driver, `useMultipartUpload()` automatically uses
 
 ### Full Example
 
-::code-group
-```ts [server/api/files/multipart/[action]/[...pathname].ts]
-import { blob } from 'hub:blob'
+::tabs{sync="blob-provider"}
+  :::tabs-item{label="R2/S3/FS" icon="i-lucide-hard-drive"}
+  ::code-group
+  ```ts [server/api/files/multipart/[action]/[...pathname].ts]
+  import { blob } from 'hub:blob'
 
-export default eventHandler(async (event) => {
-  return blob.handleMultipartUpload(event, {
-    addRandomSuffix: true,
-    prefix: 'uploads',
+  export default eventHandler(async (event) => {
+    return blob.handleMultipartUpload(event, {
+      addRandomSuffix: true,
+      prefix: 'uploads',
+    })
   })
-})
-```
-```vue [pages/upload-large.vue]
+  ```
+  ```vue [pages/upload-large.vue]
 <script setup lang="ts">
 const mpu = useMultipartUpload('/api/files/multipart', {
   partSize: 10 * 1024 * 1024, // 10MB parts
@@ -409,7 +427,90 @@ async function cancelUpload() {
     </div>
   </div>
 </template>
-```
+  ```
+  ::
+  :::
+
+  :::tabs-item{label="Vercel Blob" icon="i-simple-icons-vercel"}
+  ::code-group
+  ```ts [server/api/files/multipart/[...pathname].ts]
+  import { blob } from 'hub:blob'
+
+  export default eventHandler(async (event) => {
+    return blob.handleMultipartUpload(event, {
+      addRandomSuffix: true,
+      prefix: 'uploads',
+    })
+  })
+  ```
+  ```vue [pages/upload-large.vue]
+<script setup lang="ts">
+const mpu = useMultipartUpload('/api/files/multipart', {
+  partSize: 10 * 1024 * 1024, // 10MB parts
+  concurrent: 3, // Upload 3 parts at a time
+})
+
+const file = ref<File | null>(null)
+const progress = ref(0)
+const uploading = ref(false)
+let abortUpload: (() => Promise<void>) | null = null
+
+async function startUpload() {
+  if (!file.value) return
+
+  uploading.value = true
+  progress.value = 0
+
+  const { completed, progress: uploadProgress, abort } = mpu(file.value)
+  abortUpload = abort
+
+  watch(uploadProgress, (value) => {
+    progress.value = value
+  })
+
+  try {
+    const blob = await completed
+    console.log('Uploaded:', blob)
+  } catch (error) {
+    if (error.name !== 'AbortError') {
+      console.error('Upload failed:', error)
+    }
+  } finally {
+    uploading.value = false
+    abortUpload = null
+  }
+}
+
+async function cancelUpload() {
+  if (abortUpload) {
+    await abortUpload()
+    uploading.value = false
+  }
+}
+</script>
+
+<template>
+  <div>
+    <input
+      type="file"
+      :disabled="uploading"
+      @change="(e) => file = e.target.files?.[0]"
+    >
+    <button v-if="!uploading" @click="startUpload" :disabled="!file">
+      Upload
+    </button>
+    <button v-else @click="cancelUpload">
+      Cancel
+    </button>
+    <div v-if="uploading" class="progress-bar">
+      <div :style="{ width: `${progress * 100}%` }" />
+      <span>{{ Math.round(progress * 100) }}%</span>
+    </div>
+  </div>
+</template>
+  ```
+  ::
+  :::
 ::
 
 ## Advanced Multipart

--- a/src/blob/lib/drivers/vercel-blob.ts
+++ b/src/blob/lib/drivers/vercel-blob.ts
@@ -202,6 +202,9 @@ export function createDriver(options: VercelDriverOptions = {}): BlobDriver<Verc
      */
     async handleMultipartUpload(event: H3Event, mpuOptions?: BlobMultipartOptions): Promise<HandleMPUResponse> {
       const body = await readBody<HandleUploadBody>(event)
+      if (!body || typeof body.type !== 'string') {
+        throw createError({ statusCode: 400, message: 'Invalid multipart upload request body' })
+      }
 
       const json = await handleUpload({
         body,


### PR DESCRIPTION
Fixes #762

## Problem
`handleMultipartUpload` throws cryptic 500 error "cannot read properties of undefined (reading 'type')" when request body is empty/invalid.

## Changes
1. **Fix**: Added body validation in `vercel-blob.ts` before passing to Vercel's `handleUpload`
2. **Docs**: Clarified that Vercel Blob uses `[...pathname]` route pattern (no `[action]`)

## Reproduction
```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-762 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-762
cd nuxthub-762 && pnpm i && pnpm dev
```

Trigger error (in another terminal):
```bash
curl -X POST http://localhost:3005/api/blob/multipart/test.pdf -H "Content-Type: application/json"
```

**Before:** 500 `Cannot read properties of undefined (reading 'type')`

## Verify fix
```bash
cd .. && git sparse-checkout add nuxthub-762-fixed
cd nuxthub-762-fixed && pnpm i && pnpm dev
```

Same curl command now returns:

**After:** 400 `Invalid multipart upload request body`

The `-fixed` folder includes a pnpm patch with the fix.
