### PR TITLE
fix(kv,cache): merge default binding when driver explicitly set

### DIFF
--- a/src/cache/setup.ts
+++ b/src/cache/setup.ts
@@ -16,6 +16,9 @@ export function resolveCacheConfig(hub: HubConfig): ResolvedCacheConfig | false 
 
   // If driver is already specified by user, use it with their options
   if (userConfig.driver) {
+    if (userConfig.driver === 'cloudflare-kv-binding') {
+      return defu(userConfig, { binding: 'CACHE' }) as ResolvedCacheConfig
+    }
     return userConfig as ResolvedCacheConfig
   }
 

--- a/src/kv/setup.ts
+++ b/src/kv/setup.ts
@@ -13,6 +13,9 @@ export function resolveKVConfig(hub: HubConfig): ResolvedKVConfig | false {
 
   // If driver is already specified by user, use it with their options
   if (typeof hub.kv === 'object' && 'driver' in hub.kv) {
+    if (hub.kv.driver === 'cloudflare-kv-binding') {
+      return defu(hub.kv, { binding: 'KV' }) as ResolvedKVConfig
+    }
     return hub.kv as ResolvedKVConfig
   }
 


### PR DESCRIPTION
Fixes #766

## Problem

When explicitly setting `driver: 'cloudflare-kv-binding'` in hub.kv/cache config, `resolveKVConfig()` and `resolveCacheConfig()` return early without merging the default binding. This causes unstorage to fall back to `'STORAGE'` binding which doesn't exist.

## Solution

Merge default binding (`'KV'` for kv, `'CACHE'` for cache) when driver is explicitly set to `cloudflare-kv-binding`.

## Reproduce bug

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-766 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-766
cd nuxthub-766 && pnpm i && pnpm build && cat .nuxt/hub/kv.mjs
```

Shows `driver({})` - empty options.

## Verify fix

```bash
git sparse-checkout add nuxthub-766-fixed
cd ../nuxthub-766-fixed && pnpm i && pnpm build && cat .nuxt/hub/kv.mjs
```

Shows `driver({"binding":"KV"})`.


## Test?

Let me know if we should include tests to avoid future regressions