### PR TITLE
fix - Updated Example Schema

### DIFF
--- a/docs/content/docs/2.database/1.index.md
+++ b/docs/content/docs/2.database/1.index.md
@@ -258,7 +258,7 @@ export const users = pgTable('users', {
   id: serial().primaryKey(),
   firstName: text().notNull(), // Maps to first_name in the database
   lastName: text().notNull(),  // Maps to last_name in the database
-  createdAt: timestamp().notNull().defaultNow() // Maps to created_at
+  createdAt: timestamp().notNull().default(sql`CURRENT_TIMESTAMP`) // Maps to created_at
 })
 ```
 


### PR DESCRIPTION
In the database documentation about casing, the example schema uses the deprecated `defaultNow` function. I have updated it to the correct ```.default(sql`CURRENT_TIMESTAMP`)```.

P.S. Please let me know if I should have done anything deferent. This is my first contribution to another repository :)