### PR TITLE
docs: clarify migration guide for v0.10.3+

### DIFF
--- a/docs/content/docs/1.getting-started/4.migration.md
+++ b/docs/content/docs/1.getting-started/4.migration.md
@@ -4,7 +4,11 @@ description: "Learn how to migrate your NuxtHub project to be multi-cloud compat
 navigation.title: "Migration"
 ---
 
-NuxtHub v0.10 introduces a significant shift toward **multi-cloud support** and **self-hosting**, moving away from the Cloudflare-exclusive approach of older versions. This guide will help you migrate your existing project.
+NuxtHub v0.10 introduces a significant shift toward **multi-cloud support** and **self-hosting**, moving away from the Cloudflare-exclusive approach of older versions. This guide will help you migrate your existing v0.9 project to v0.10.
+
+::important
+This guide covers migration from **v0.9 to v0.10**. If you're using the NuxtHub Admin migration wizard, note that some instructions may reference older versions and can be disregarded in favor of this documentation.
+::
 
 ## Overview of Changes
 
@@ -221,14 +225,58 @@ export default eventHandler(async () => {
 
 With NuxtHub v0.10, you deploy your project directly to your cloud provider using their tooling.
 
-#### Cloudflare
+::note
+Since v0.10.3, NuxtHub auto-generates Cloudflare bindings from your `nuxt.config.ts` at build time. Manual `wrangler.jsonc` configuration is optional.
+::
+
+### Cloudflare
+
+NuxtHub supports two approaches for Cloudflare deployment. Choose based on your preference.
+
+#### Option A: Auto-Configuration (Recommended)
+
+NuxtHub auto-generates the `wrangler.json` file at build time when you provide resource IDs in your config. No manual `wrangler.jsonc` is required.
 
 1. Create the necessary resources in your [Cloudflare dashboard](https://dash.cloudflare.com):
    - [D1 Database](https://dash.cloudflare.com/?to=/:account/workers/d1) (if using `hub.db`)
    - [KV Namespace](https://dash.cloudflare.com/?to=/:account/workers/kv/namespaces) (if using `hub.kv` or `hub.cache`)
    - [R2 Bucket](https://dash.cloudflare.com/?to=/:account/r2/new) (if using `hub.blob`)
 
-2. Create a `wrangler.jsonc` file in your project root:
+2. Configure bindings in `nuxt.config.ts`:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  hub: {
+    // D1 database
+    db: {
+      dialect: 'sqlite',
+      driver: 'd1',
+      connection: { databaseId: '<database-id>' }
+    },
+    // KV namespace (binding defaults to 'KV')
+    kv: {
+      driver: 'cloudflare-kv-binding',
+      namespaceId: '<kv-namespace-id>'
+    },
+    // Cache KV namespace (binding defaults to 'CACHE')
+    cache: {
+      driver: 'cloudflare-kv-binding',
+      namespaceId: '<cache-namespace-id>'
+    },
+    // R2 bucket (binding defaults to 'BLOB')
+    blob: {
+      driver: 'cloudflare-r2',
+      bucketName: '<bucket-name>'
+    }
+  }
+})
+```
+
+3. Deploy using [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) or [Pages CI](https://developers.cloudflare.com/pages/configuration/git-integration/github-integration/)
+
+#### Option B: Manual wrangler.jsonc
+
+Alternatively, you can create a `wrangler.jsonc` file manually in your project root:
 
 ```jsonc [wrangler.jsonc]
 {
@@ -259,9 +307,11 @@ With NuxtHub v0.10, you deploy your project directly to your cloud provider usin
 }
 ```
 
-3. Deploy using [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) or [Pages CI](https://developers.cloudflare.com/pages/configuration/git-integration/github-integration/)
+::callout{to="/docs/getting-started/deploy#cloudflare"}
+See the deployment documentation for more details on Cloudflare configuration, environments, and CI/CD setup.
+::
 
-#### Vercel
+### Vercel
 
 1. Install required packages based on features used:
 
@@ -330,8 +380,9 @@ Replace `npx nuxthub deploy` with your provider's deployment method:
 - [ ] Replace `hubBlob()` calls with `blob` from `hub:blob`
 - [ ] Replace `hubKV()` calls with `kv` from `hub:kv`
 - [ ] Remove AI/AutoRAG usage or migrate to AI SDK
-- [ ] Set up self-hosting with your cloud provider
-- [ ] Update CI/CD from NuxtHub GitHub Action to provider's deployment
+- [ ] For Cloudflare: Configure resource IDs in `nuxt.config.ts` (v0.10.3+) OR create manual `wrangler.jsonc`
+- [ ] For Vercel: Add storage from dashboard and install required packages
+- [ ] Update CI/CD from NuxtHub GitHub Action to provider's deployment (Workers/Pages CI, Vercel Git integration, etc.)
 
 ## Getting Help
 


### PR DESCRIPTION
In some discord channels, and also a coworker of mine, have shown some frustation when migrating to NuxtHub.

My coworker specifically said:

> The migration of Nuxthub to Cloudflare is weird.
> The migration "wizard" of NuxtHub admin says to change the Nitro preset to cloudflare_modulebut that is not mentionend anywhere else in the migration docs. The wrangler config is also different across docs and wizard. How can one even be sure to have the right settings?
> And why would we even still need the nuxthub Nuxt module?
> And then the docs for installing v10 say one doesn't neven need a wranger.jsonc. https://hub.nuxt.com/docs/getting-started/deploy wtf 

I think there is room for improvment and the guide can be clearer

## Summary

Clarifies the migration guide to address confusion around wrangler configuration and version scope.

**Key improvements:**
- Explicitly states this is v0.9 → v0.10 migration (not v0.5)
- Highlights v0.10.3+ auto-generates wrangler.json from nuxt.config.ts
- Restructures Cloudflare section into two clear options:
  - **Option A (Recommended)**: Config in nuxt.config.ts → auto-generated wrangler.json
  - **Option B**: Manual wrangler.jsonc
- Updates migration checklist with provider-specific steps
- Warns migration wizard may show outdated v0.5 instructions

**Resolves confusion:**
- "Migration wizard says use cloudflare_module preset" → Now clarified as outdated v0.5 info
- "Wrangler config different across docs" → Now consistent with deploy.md
- "Docs say no wrangler.jsonc needed" → Now explicit that it's optional since v0.10.3
