### PR TITLE
docs: add projectUrl migration guide

### DIFF
--- a/docs/content/docs/1.getting-started/4.migration.md
+++ b/docs/content/docs/1.getting-started/4.migration.md
@@ -33,6 +33,7 @@ You can visit [legacy.hub.nuxt.com](https://legacy.hub.nuxt.com) to read the doc
 | Blob access | `hubBlob()` | `blob` from `hub:blob` |
 | KV access | `hubKV()` | `kv` from `hub:kv` |
 | AI & AutoRAG | `hubAI()` | Removed (use [AI SDK](https://ai-sdk.dev)) |
+| Remote storage | `hub.projectUrl` + `hub.projectSecretKey` | `wrangler.jsonc` with `remote: true` per binding |
 | NuxtHub Admin | Supported | Deprecated (sunset Dec 31, 2025) |
 | `nuxthub deploy` | Supported | Deprecated (sunset Jan 31, 2026) |
 
@@ -92,6 +93,31 @@ export default defineNuxtConfig({
   }
 })
 ```
+
+### Remote Storage
+
+The `projectUrl` and `projectSecretKey` options have been removed. To connect to remote Cloudflare resources during local development, use wrangler's native `remote: true` flag on each binding in your `wrangler.jsonc`:
+
+```jsonc [wrangler.jsonc]
+{
+  "d1_databases": [
+    { "binding": "DB", "database_name": "<name>", "database_id": "<id>", "remote": true }
+  ],
+  "r2_buckets": [
+    { "binding": "BLOB", "bucket_name": "<name>", "remote": true }
+  ],
+  "kv_namespaces": [
+    { "binding": "KV", "id": "<id>", "remote": true },
+    { "binding": "CACHE", "id": "<id>", "remote": true }
+  ]
+}
+```
+
+This requires wrangler v4.37.0+. When `remote: true` is set, your code runs locally but binding calls are routed to actual Cloudflare resources.
+
+::callout{to="https://developers.cloudflare.com/workers/development-testing/#remote-bindings"}
+Learn more about wrangler remote bindings.
+::
 
 ## Code Migration
 
@@ -380,6 +406,7 @@ Replace `npx nuxthub deploy` with your provider's deployment method:
 - [ ] Replace `hubBlob()` calls with `blob` from `hub:blob`
 - [ ] Replace `hubKV()` calls with `kv` from `hub:kv`
 - [ ] Remove AI/AutoRAG usage or migrate to AI SDK
+- [ ] For remote development: Add `remote: true` to bindings in `wrangler.jsonc`
 - [ ] For Cloudflare: Configure resource IDs in `nuxt.config.ts` (v0.10.3+) OR create manual `wrangler.jsonc`
 - [ ] For Vercel: Add storage from dashboard and install required packages
 - [ ] Update CI/CD from NuxtHub GitHub Action to provider's deployment (Workers/Pages CI, Vercel Git integration, etc.)


### PR DESCRIPTION
Fixes #771

Adds missing migration documentation for `projectUrl` and `projectSecretKey` options that were removed in v0.10:

- Added row to Breaking Changes Summary table
- Added "Remote Storage" section explaining the migration from `projectUrl`/`projectSecretKey` to `hub.remote: true`
- Added checklist item for the migration step

> [!NOTE]
> This PR documents `hub.remote: true` which is introduced in #742. Should be merged after #742.