### PR TITLE
fix(db): use libsql in dev mode when cloudflare preset is set

### DIFF
--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -74,7 +74,8 @@ export async function resolveDatabaseConfig(nuxt: Nuxt, hub: HubConfig): Promise
         }
         break
       }
-      if (hub.hosting.includes('cloudflare')) {
+      // Cloudflare D1 (production only - dev uses local libsql)
+      if (hub.hosting.includes('cloudflare') && !nuxt.options.dev) {
         config.driver = 'd1'
         break
       }

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -43,8 +43,13 @@ async function launchDrizzleStudio(nuxt: Nuxt, hub: HubConfig) {
       await startStudioMySQLServer(schema, connection, { port })
     } else if (dialect === 'sqlite') {
       const { startStudioSQLiteServer } = await import('drizzle-kit/api')
-      log.info(`Launching Drizzle Studio with SQLite...`)
-      await startStudioSQLiteServer(schema, connection as any, { port })
+      log.info(`Launching Drizzle Studio with SQLite (${driver})...`)
+      // drizzle-kit auto-detects libsql from @libsql/client package
+      // Only pass driver for d1-http, otherwise just pass connection
+      const studioConnection = driver === 'd1-http'
+        ? { driver: 'd1-http', ...connection }
+        : connection
+      await startStudioSQLiteServer(schema, studioConnection as any, { port })
     } else {
       throw new Error(`Unsupported database dialect: ${dialect}`)
     }


### PR DESCRIPTION
Closes #772

## Summary
When `NITRO_PRESET=cloudflare-pages` is set, D1 driver was selected in dev mode causing DevTools Database panel to fail. Fix uses libsql driver in dev mode (D1 only for production).

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [hub-772](https://stackblitz.com/github/onmax/repros/tree/repro/hub-772/hub-772?startScript=dev) | ❌ DevTools → Database → Launch fails |
| Fix | [hub-772-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/hub-772/hub-772-fixed?startScript=dev) | ✅ Drizzle Studio opens |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/hub-772 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set hub-772
cd hub-772 && pnpm i && pnpm dev
# Open DevTools → Database → Launch → Error
```

## Verify fix

```bash
git sparse-checkout add hub-772-fixed
cd ../hub-772-fixed && pnpm i && pnpm dev
# Open DevTools → Database → Launch → Works
```

The `-fixed` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.