### PR TITLE
fix(db): use DATABASE_URL when no hyperdriveId configured

### DIFF
--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -118,6 +118,10 @@ export async function setupDatabase(nuxt: Nuxt, hub: HubConfig, deps: Record<str
     const binding = driver === 'postgres-js' ? 'POSTGRES' : 'MYSQL'
     addWranglerBinding(nuxt, 'hyperdrive', { binding, id: connection.hyperdriveId })
   }
+  if (['postgres-js', 'mysql2'].includes(driver) && hub.hosting.includes('cloudflare') && !connection?.hyperdriveId && !connection?.url) {
+    const envVar = driver === 'postgres-js' ? 'DATABASE_URL' : 'MYSQL_URL'
+    log.warn(`Using \`${driver}\` on Cloudflare without \`hyperdriveId\` or \`${envVar}\`. Ensure ${envVar} is set at runtime.`)
+  }
 
   // Verify development database dependencies are installed
   if (!deps['drizzle-orm'] || !deps['drizzle-kit']) {
@@ -403,7 +407,7 @@ const db = drizzle(d1HttpDriver, { schema${casingOption} })
 export { db, schema }
 `
   }
-  if (['postgres-js', 'mysql2'].includes(driver) && hub.hosting.includes('cloudflare')) {
+  if (['postgres-js', 'mysql2'].includes(driver) && hub.hosting.includes('cloudflare') && connection?.hyperdriveId) {
     // Hyperdrive requires lazy binding access - bindings only available in request context on CF Workers
     const bindingName = driver === 'postgres-js' ? 'POSTGRES' : 'MYSQL'
     drizzleOrmContent = `import { drizzle } from 'drizzle-orm/${driver}'


### PR DESCRIPTION
Fixes #777

## Problem

When using `hub: { db: 'postgresql' }` with `DATABASE_URL` on Cloudflare, the generated `db.mjs` looks for a `POSTGRES` Hyperdrive binding instead of using the connection URL directly.

## Solution

Only use Hyperdrive binding code when `hyperdriveId` is explicitly configured. Otherwise, use the connection URL from `DATABASE_URL`.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxthub-777](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-777/nuxthub-777?startScript=build) | ❌ `POSTGRES binding not found` |
| Fix | [nuxthub-777-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-777/nuxthub-777-fixed?startScript=build) | ✅ Uses DATABASE_URL |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-777 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-777
cd nuxthub-777 && pnpm i && NITRO_PRESET=cloudflare-pages pnpm build
cat .nuxt/hub/db.mjs  # Shows POSTGRES binding code
```

## Verify fix

```bash
git sparse-checkout add nuxthub-777-fixed
cd ../nuxthub-777-fixed && pnpm i && NITRO_PRESET=cloudflare-pages pnpm build
cat .nuxt/hub/db.mjs  # Shows direct connection URL
```

The `-fixed` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.