### PR TITLE
fix: enable Node.js compatibility for Cloudflare Workers

### DIFF
--- a/src/hosting/cloudflare.ts
+++ b/src/hosting/cloudflare.ts
@@ -24,7 +24,7 @@ export const cloudflareHooks = createHooks<CloudflareHooks>()
 export function setupCloudflare(nuxt: Nuxt, hub: HubConfig) {
   // Enable Cloudflare Node.js compatibility
   nuxt.options.nitro.cloudflare ||= {}
-  nuxt.options.nitro.cloudflare.nodeCompat = false
+  nuxt.options.nitro.cloudflare.nodeCompat = true
   nuxt.options.nitro.cloudflare.deployConfig = true
   // Remove trailing slash for prerender routes
   nuxt.options.nitro.prerender ||= {}


### PR DESCRIPTION
Closes #711

## Summary

`nodeCompat = false` was accidentally shipped in v0.10.1, breaking Node.js crypto APIs on Cloudflare Workers. Password verification with scrypt fails silently.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxthub-711](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-711/nuxthub-711?startScript=build) | ❌ crypto stubbed |
| Fix | [nuxthub-711-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-711/nuxthub-711-fixed?startScript=build) | ✅ node:crypto external |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-711 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-711
cd nuxthub-711 && pnpm i && pnpm build
```

## Verify fix

```bash
git sparse-checkout add nuxthub-711-fixed
cd ../nuxthub-711-fixed && pnpm i && pnpm build
```

---

<details>
<summary><b>Investigation Details</b></summary>

### Git History

The bug originated in commit `b00d094` ("chore: try to set compat flag manually") during a debugging session:

```
38d7ed8 chore: revert compat date
4ae483a chore: try using nitro default with latest compat date
b2cb2fc fix: add no_bundle mode
b00d094 chore: try to set compat flag manually  ← nodeCompat changed to false
96517c5 chore: try bundling again
030a0ce chore(release): v0.10.1  ← shipped broken
```

Later moved to `cloudflare.ts` in PR #720 (`cec8c89`), keeping `nodeCompat = false`.

The comment says "// Enable Cloudflare Node.js compatibility" but the code disables it.

### Why Two Things Are Needed

Cloudflare Workers Node.js compatibility requires **two layers**:

| Layer | Config | Purpose |
|-------|--------|---------|
| **Build-time** | `nodeCompat: true` | Applies Nitro's `unenvCfNodeCompat` preset, marks `node:*` as external |
| **Runtime** | `nodejs_compat` flag | Tells workerd to provide Node.js modules |

From Nitro source (`src/presets/cloudflare/utils.ts`):

```ts
export async function enableNodeCompat(nitro: Nitro) {
  nitro.options.cloudflare.nodeCompat ??= true;  // defaults to true
  if (nitro.options.cloudflare.nodeCompat) {
    nitro.options.unenv.push(unenvCfNodeCompat);  // THIS IS SKIPPED when false
  }
}
```

The `unenvCfNodeCompat` preset marks `node:crypto` and other modules as **external**, so rollup leaves `import 'node:crypto'` as-is instead of bundling polyfills.

### What Went Wrong

NuxtHub was setting:
- `nodeCompat = false` → unenv preset NOT applied → rollup bundles broken polyfills
- `nodejs_compat` flag in wrangler.json → runtime can provide modules, but bundler already polyfilled them

Result: incomplete crypto polyfills at build time. User @raress96 confirmed: `[unenv] crypto.createHash is not implemented yet!`

### Build Output Comparison

| Version | `nitro.mjs` size | Reason |
|---------|------------------|--------|
| Bug (`nodeCompat: false`) | 154 KB | Bundles crypto polyfills |
| Fix (`nodeCompat: true`) | 108 KB | `node:crypto` external |

</details>