### PR TITLE
docs(blob): add image provider dev limitations

### DIFF
--- a/docs/content/docs/3.blob/1.index.md
+++ b/docs/content/docs/3.blob/1.index.md
@@ -236,9 +236,11 @@ Configure `@nuxt/image` to use the appropriate provider for your hosting platfor
   :::tabs-item{label="Cloudflare" icon="i-simple-icons-cloudflare"}
   ```ts [nuxt.config.ts]
   export default defineNuxtConfig({
-    image: {
-      provider: 'cloudflare',
-      cloudflare: { baseURL: '/images' }
+    $production: {
+      image: {
+        provider: 'cloudflare',
+        cloudflare: { baseURL: '/images' }
+      }
     }
   })
   ```
@@ -247,13 +249,12 @@ Configure `@nuxt/image` to use the appropriate provider for your hosting platfor
   ::
   :::
   :::tabs-item{label="Vercel" icon="i-simple-icons-vercel"}
-  ::tip
-  When deploying to Vercel, it automatically configures the Vercel Image provider.
-  ::
   ```ts [nuxt.config.ts]
   export default defineNuxtConfig({
-    image: {
-      provider: 'vercel'
+    $production: {
+      image: {
+        provider: 'vercel'
+      }
     }
   })
   ```
@@ -261,6 +262,10 @@ Configure `@nuxt/image` to use the appropriate provider for your hosting platfor
   See Vercel provider docs for requirements and options.
   ::
   :::
+::
+
+::warning{title="Development Limitation"}
+These providers use platform-specific endpoints (`/cdn-cgi/image/` for Cloudflare, `/_vercel/image` for Vercel) that only exist in production. Using `$production` ensures images load directly from blob storage during local development.
 ::
 
 ### Use NuxtImg or NuxtPicture


### PR DESCRIPTION
## Problem

Image providers like Cloudflare and Vercel use platform-specific endpoints that don't exist in local dev:
- Cloudflare: `/cdn-cgi/image/...`
- Vercel: `/_vercel/image`

Related: #521

## Solution

- Use `$production` wrapper in examples
- Add warning explaining why and what happens in dev