### PR TITLE
fix(db): skip tsconfig resolution during schema build

### DIFF
--- a/src/db/lib/build.ts
+++ b/src/db/lib/build.ts
@@ -98,6 +98,7 @@ export async function buildDatabaseSchema(buildDir: string, { relativeDir }: { r
     platform: 'neutral',
     format: 'esm',
     skipNodeModulesBundle: true,
+    tsconfig: false,
     dts: {
       build: false,
       tsconfig: false,


### PR DESCRIPTION
Follow-up to #758

## Problem

First `nuxi prepare` fails on fresh project when `.nuxt/` doesn't exist.

```
[UNHANDLEABLE_ERROR] Error: Tsconfig not found .nuxt/tsconfig.json
Caused by: Failed to resolve tsconfig option
```

PR #758 enabled schema building during prepare, but rolldown tries to resolve the project's `tsconfig.json` which extends `.nuxt/tsconfig.json` - a file that doesn't exist yet.

## Fix

Add `tsconfig: false` at the top level of tsdown build options. This prevents rolldown from resolving the tsconfig chain while still generating `.d.mts` types.

## StackBlitz

| | Link |
|---|---|
| Bug | [nuxthub-758](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-758/nuxthub-758?startScript=prepare) |
| Fix | [nuxthub-758-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-758/nuxthub-758-fixed?startScript=prepare) |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-758 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-758
cd nuxthub-758 && pnpm i && pnpm prepare  # fails
```

## Verify fix

```bash
git sparse-checkout add nuxthub-758-fixed
cd ../nuxthub-758-fixed && pnpm i && pnpm prepare  # succeeds
ls .nuxt/hub/db/  # schema.mjs + schema.d.mts exist
```