### PR TITLE
fix(db): use dynamic import for migrations plugin

### DIFF
--- a/src/db/runtime/plugins/migrations.dev.ts
+++ b/src/db/runtime/plugins/migrations.dev.ts
@@ -1,7 +1,5 @@
 import type { ResolvedHubConfig } from '../../../types'
 import { applyDatabaseMigrations, applyDatabaseQueries } from '../../lib/migrations'
-// @ts-expect-error - Generated at runtime
-import { db } from 'hub:db'
 import { defineNitroPlugin, useRuntimeConfig } from '#imports'
 
 export default defineNitroPlugin(async () => {
@@ -9,6 +7,17 @@ export default defineNitroPlugin(async () => {
 
   const hub = useRuntimeConfig().hub as ResolvedHubConfig
   if (!hub.db) return
+
+  let db
+  try {
+    const module = await import('hub:db')
+    db = module.db
+  } catch (error) {
+    console.error('[nuxt:hub] Failed to import hub:db module:', error instanceof Error ? error.message : error)
+    console.error('[nuxt:hub] This may happen when using remote bindings before the proxy is initialized.')
+    console.error('[nuxt:hub] Migrations will be skipped. Please ensure remote bindings are properly configured.')
+    return
+  }
 
   await applyDatabaseMigrations(hub, db)
   await applyDatabaseQueries(hub, db)


### PR DESCRIPTION
## Summary
- Static import of `hub:db` fails when remote bindings proxy isn't initialized yet
- Migration plugin runs early, causing timing issues with remote plugin's async `getPlatformProxy()`

## Fix
- Dynamic import with try/catch + helpful error messages

Closes #741