### PR TITLE
fix(db): lazy URL resolution for Docker/K8s deployments

### DIFF
--- a/docs/content/docs/2.database/1.index.md
+++ b/docs/content/docs/2.database/1.index.md
@@ -28,7 +28,7 @@ Install Drizzle ORM, Drizzle Kit, and the appropriate driver(s) for the database
     ::callout
     NuxtHub automatically detects your database connection using environment variables:
     - Uses `mysql2` driver if you set `DATABASE_URL` or `MYSQL_URL` environment variable.
-    - Requires environment variable (no local fallback)
+    - Requires environment variable (no local fallback).
     ::
   :::
   :::tabs-item{label="SQLite" icon="i-simple-icons-sqlite"}
@@ -42,6 +42,10 @@ Install Drizzle ORM, Drizzle Kit, and the appropriate driver(s) for the database
     For Cloudflare D1, configure the database ID in your `nuxt.config.ts` and NuxtHub auto-generates the wrangler bindings.
     ::
   :::
+::
+
+::tip{to="#dockerkubernetes-deployments"}
+For containerized deployments, you can defer environment variables to runtime.
 ::
 
 ### Set SQL dialect
@@ -268,7 +272,7 @@ Learn more about [camel and snake casing](https://orm.drizzle.team/docs/sql-sche
 
 ### D1 over HTTP
 
-Use the `d1-http` driver to access a Cloudflare D1 database over HTTP. This is useful when you want to query your D1 database when hosting on other platforms.
+Use the `d1-http` driver to access a Cloudflare D1 database over HTTP when hosting on other platforms.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -295,7 +299,7 @@ You can find your Cloudflare account ID and create API tokens in the [Cloudflare
 
 ### Neon Serverless
 
-Use the `neon-http` driver to connect to [Neon](https://neon.com) serverless PostgreSQL. This driver uses HTTP protocol optimized for serverless environments.
+Use the `neon-http` driver to connect to [Neon](https://neon.com) serverless PostgreSQL with HTTP protocol optimized for serverless environments.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -310,9 +314,7 @@ export default defineNuxtConfig({
 
 Install the required dependency:
 
-```bash
-pnpm add @neondatabase/serverless
-```
+:pm-install{name="@neondatabase/serverless"}
 
 This driver requires the following environment variable:
 
@@ -322,6 +324,77 @@ This driver requires the following environment variable:
 
 ::callout{icon="i-lucide-info"}
 You can find your Neon connection string in the [Neon dashboard](https://console.neon.tech). The connection string format is `postgresql://user:password@hostname/database`.
+::
+
+### Docker/Kubernetes Deployments
+
+Build container images without database credentials by deferring environment resolution to runtime. Set the driver explicitly and disable build-time migrations:
+
+::tabs{sync="database-dialect"}
+  :::tabs-item{label="SQLite" icon="i-simple-icons-sqlite"}
+  ```ts [nuxt.config.ts]
+  export default defineNuxtConfig({
+    hub: {
+      db: {
+        dialect: 'sqlite',
+        driver: 'libsql',
+        applyMigrationsDuringBuild: false
+      }
+    }
+  })
+  ```
+  :::
+  :::tabs-item{label="PostgreSQL" icon="i-simple-icons-postgresql"}
+  ```ts [nuxt.config.ts]
+  export default defineNuxtConfig({
+    hub: {
+      db: {
+        dialect: 'postgresql',
+        driver: 'postgres-js', // or 'neon-http'
+        applyMigrationsDuringBuild: false
+      }
+    }
+  })
+  ```
+  :::
+  :::tabs-item{label="MySQL" icon="i-simple-icons-mysql"}
+  ```ts [nuxt.config.ts]
+  export default defineNuxtConfig({
+    hub: {
+      db: {
+        dialect: 'mysql',
+        driver: 'mysql2',
+        applyMigrationsDuringBuild: false
+      }
+    }
+  })
+  ```
+  :::
+::
+
+Set these environment variables at runtime:
+
+::tabs{sync="database-dialect"}
+  :::tabs-item{label="SQLite" icon="i-simple-icons-sqlite"}
+  | Variable | Description |
+  | --- | --- |
+  | `TURSO_DATABASE_URL` | Connection URL for Turso or libSQL. Falls back to `LIBSQL_URL`, then `DATABASE_URL`. |
+  | `TURSO_AUTH_TOKEN` | Authentication token for remote databases. Falls back to `LIBSQL_AUTH_TOKEN`. |
+  :::
+  :::tabs-item{label="PostgreSQL" icon="i-simple-icons-postgresql"}
+  | Variable | Description |
+  | --- | --- |
+  | `POSTGRES_URL` | Connection URL for PostgreSQL. Falls back to `POSTGRESQL_URL`, then `DATABASE_URL`. |
+  :::
+  :::tabs-item{label="MySQL" icon="i-simple-icons-mysql"}
+  | Variable | Description |
+  | --- | --- |
+  | `MYSQL_URL` | Connection URL for MySQL. Falls back to `DATABASE_URL`. |
+  :::
+::
+
+::tip
+Apply migrations manually after deployment using `npx nuxt db migrate` or your CI/CD pipeline.
 ::
 
 ## AI Agents

--- a/test/database.config.test.ts
+++ b/test/database.config.test.ts
@@ -152,6 +152,24 @@ describe('resolveDatabaseConfig', () => {
         }
       })
     })
+
+    it('should allow libsql without env vars for lazy resolution (K8s/Docker)', async () => {
+      const nuxt = createMockNuxt()
+      const hub = createBaseHubConfig({
+        dialect: 'sqlite',
+        driver: 'libsql',
+        applyMigrationsDuringBuild: false
+      })
+
+      const result = await resolveDatabaseConfig(nuxt, hub)
+
+      expect(result).toMatchObject({
+        dialect: 'sqlite',
+        driver: 'libsql',
+        connection: { url: '' },
+        applyMigrationsDuringBuild: false
+      })
+    })
   })
 
   describe('PostgreSQL dialect', () => {
@@ -275,16 +293,51 @@ describe('resolveDatabaseConfig', () => {
       })
     })
 
-    it('should throw error when DATABASE_URL is not set for neon-http', async () => {
+    it('should throw error when DATABASE_URL is not set for neon-http with applyMigrationsDuringBuild', async () => {
       const nuxt = createMockNuxt()
       const hub = createBaseHubConfig({
         dialect: 'postgresql',
-        driver: 'neon-http'
+        driver: 'neon-http',
+        applyMigrationsDuringBuild: true
       })
 
       await expect(resolveDatabaseConfig(nuxt, hub)).rejects.toThrow(
-        '`neon-http` driver requires `DATABASE_URL`, `POSTGRES_URL`, or `POSTGRESQL_URL` environment variable'
+        '`neon-http` driver requires `DATABASE_URL`, `POSTGRES_URL`, or `POSTGRESQL_URL` environment variable when `applyMigrationsDuringBuild` is enabled'
       )
+    })
+
+    it('should allow neon-http without DATABASE_URL when applyMigrationsDuringBuild is false', async () => {
+      const nuxt = createMockNuxt()
+      const hub = createBaseHubConfig({
+        dialect: 'postgresql',
+        driver: 'neon-http',
+        applyMigrationsDuringBuild: false
+      })
+
+      const result = await resolveDatabaseConfig(nuxt, hub)
+
+      expect(result).toMatchObject({
+        dialect: 'postgresql',
+        driver: 'neon-http',
+        applyMigrationsDuringBuild: false
+      })
+    })
+
+    it('should allow postgres-js without DATABASE_URL when applyMigrationsDuringBuild is false', async () => {
+      const nuxt = createMockNuxt()
+      const hub = createBaseHubConfig({
+        dialect: 'postgresql',
+        driver: 'postgres-js',
+        applyMigrationsDuringBuild: false
+      })
+
+      const result = await resolveDatabaseConfig(nuxt, hub)
+
+      expect(result).toMatchObject({
+        dialect: 'postgresql',
+        driver: 'postgres-js',
+        applyMigrationsDuringBuild: false
+      })
     })
   })
 
@@ -323,13 +376,32 @@ describe('resolveDatabaseConfig', () => {
       })
     })
 
-    it('should throw error when no DATABASE_URL or MYSQL_URL is set', async () => {
+    it('should throw error when no DATABASE_URL or MYSQL_URL is set with applyMigrationsDuringBuild', async () => {
       const nuxt = createMockNuxt()
-      const hub = createBaseHubConfig('mysql')
+      const hub = createBaseHubConfig({
+        dialect: 'mysql',
+        applyMigrationsDuringBuild: true
+      })
 
       await expect(resolveDatabaseConfig(nuxt, hub)).rejects.toThrow(
-        'MySQL requires DATABASE_URL or MYSQL_URL environment variable'
+        'MySQL requires DATABASE_URL or MYSQL_URL environment variable when `applyMigrationsDuringBuild` is enabled'
       )
+    })
+
+    it('should allow mysql2 without DATABASE_URL when applyMigrationsDuringBuild is false', async () => {
+      const nuxt = createMockNuxt()
+      const hub = createBaseHubConfig({
+        dialect: 'mysql',
+        applyMigrationsDuringBuild: false
+      })
+
+      const result = await resolveDatabaseConfig(nuxt, hub)
+
+      expect(result).toMatchObject({
+        dialect: 'mysql',
+        driver: 'mysql2',
+        applyMigrationsDuringBuild: false
+      })
     })
 
     it('should preserve custom driver when specified', async () => {
@@ -587,14 +659,17 @@ describe('resolveDatabaseConfig', () => {
       })
     })
 
-    it('should handle empty string as db connection URL', async () => {
+    it('should handle empty string as db connection URL with applyMigrationsDuringBuild', async () => {
       process.env.DATABASE_URL = ''
 
       const nuxt = createMockNuxt()
-      const hub = createBaseHubConfig('mysql')
+      const hub = createBaseHubConfig({
+        dialect: 'mysql',
+        applyMigrationsDuringBuild: true
+      })
 
       await expect(resolveDatabaseConfig(nuxt, hub)).rejects.toThrow(
-        'MySQL requires DATABASE_URL or MYSQL_URL environment variable'
+        'MySQL requires DATABASE_URL or MYSQL_URL environment variable when `applyMigrationsDuringBuild` is enabled'
       )
     })
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    testTimeout: 60000,
+    hookTimeout: 180000,
+    fileParallelism: false
+  }
+})


### PR DESCRIPTION
Closes #777

## Summary

Allow building without DATABASE_URL when `applyMigrationsDuringBuild: false`. Generate lazy Proxy pattern for postgres-js, neon-http, mysql2, libsql on non-CF deployments. Enables Docker multi-client scenario: build once, deploy many with different DATABASE_URLs.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxthub-777](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-777/nuxthub-777?startScript=build) | ❌ Build fails |
| Fix | [nuxthub-777-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-777/nuxthub-777-fixed?startScript=build) | ✅ Build succeeds |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-777 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-777
cd nuxthub-777 && pnpm i && pnpm build
```

## Verify fix

```bash
git sparse-checkout add nuxthub-777-fixed
cd ../nuxthub-777-fixed && pnpm i && pnpm build
cat .nuxt/hub/db.mjs  # Shows lazy env resolution
```

The `-fixed` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.

## Related
- https://github.com/nuxt-hub/core/issues/777

## Context

<details><summary>Details</summary>
<p>

Kenshi:
Hey, 
I recently switched to Nuxt-Hub for the simple database implementation and S3 support, but I have run into an issue I can't figure out how to work around. I'm working with Docker to deploy my Nuxt app and build my own Docker images for each one. After building a Nuxt app that's using the Nuxt Hub without setting anything besides the db: 'postgresql', it causes an error to occur on launch Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@electric-sql/pglite' imported from /prod/server/node_modules/drizzle-orm/pglite/driver.js. I tried to follow the documentation and had set the driver to postgres-js but that causes another issue when building the app postinstall:  ERROR  postgres-js driver requires DATABASE_URL, POSTGRES_URL, or POSTGRESQL_URL environment variable. It is not suitable for me to set the ENV variables on build as the app is being deployed for multiple clients and these change on every Nuxt Instance. 
Could you suggest any workaround for this issue? If there are any.
Thanks in advance.

EDIT: I have also tried setting the applyMigrationsDuringBuild to false but nothing changed 

NuxtHub needs to know the database env in order to apply the database migrations at build time
Kenshi
 — 
Yesterday at 8:54 AM
Yeah, I'm aware of that, that's why I tried to disable the migration at build as stated in the docs.
Atinux
 — 
Yesterday at 8:57 AM
Could you try to set a fake DATABASE_URL for the build to see if it passes?
If you disabled migrations it shouldn’t call the database anyway
Kenshi
 — 
Yesterday at 8:59 AM
We did try that, but apparently nuxt hub hard codes the variable into the cooked build instead of reading it from the env file
Feels counter intuitive to me but it is what it is
It's for all of the variables as well not only the database
Atinux
 — 
Yesterday at 10:52 AM
It should be possible to fix this
How do you plan to manage the migrations @Kenshi ?
Atinux
 — 
Yesterday at 11:22 AM
what do you think of this @onmax ?
onmax
 — 
Yesterday at 1:09 PM
Connection URL gets hardcoded into generated hub/db.mjs at build time via JSON.stringify(connection).  Cloudflare deployments (D1, Hyperdrive) work because they use lazy runtime resolution:

const binding = process.env.DB || globalThis.__env__?.DB



Non-CF deployments (postgres-js, neon-http, mysql2) don't have this.

I propose always use lazy resolution for non-CF drivers too. Zero config changes, Docker multi-client deployments would work:

function getDB() {
  const url = process.env.DATABASE_URL || process.env.POSTGRES_URL
  if (!url) throw new Error('DATABASE_URL required')
  return drizzle({ connection: url, schema })
}



Also: only require DATABASE_URL at build time if applyMigrationsDuringBuild: true.

Should I open a PR @Atinux ? Would close #777 as well.


Did i miss something?
Kenshi
 — 
Yesterday at 1:32 PM
We have it run checks and in case of changes migrations at the app launch. It might not be the cleanest solution but it works for our use case as of right now.
Vetro
 — 
Yesterday at 2:07 PM
Hey, I work with @Kenshi . It would be great if migrations could be done on application deploy, not just on build.

Also I found, that probably whole hub's config is baked into nuxt's nitro.mjs on build... blob config what was in env file (api keys for S3) is also here
Atinux
 — 
Yesterday at 2:42 PM
sounds good!

</p>
</details> 