### PR TITLE
fix(db): generate schema types during prepare

### DIFF
--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -274,11 +274,14 @@ async function generateDatabaseSchema(nuxt: Nuxt, hub: ResolvedHubConfig) {
     write: true
   })
 
+  // Build schema types during prepare/dev/build
+  nuxt.hooks.hookOnce('app:templatesGenerated', async () => {
+    await buildDatabaseSchema(nuxt.options.buildDir, { relativeDir: nuxt.options.rootDir })
+  })
+
+  // Copy schema to node_modules/@nuxthub/db/ for workflow compatibility
   if (!nuxt.options._prepare) {
     nuxt.hooks.hookOnce('app:templatesGenerated', async () => {
-      await buildDatabaseSchema(nuxt.options.buildDir, { relativeDir: nuxt.options.rootDir })
-
-      // Also copy schema.mjs to node_modules/@nuxthub/db/ for workflow compatibility
       const physicalDbDir = join(nuxt.options.rootDir, 'node_modules', '@nuxthub', 'db')
       await mkdir(physicalDbDir, { recursive: true })
 


### PR DESCRIPTION
Closes #792

## Summary

PR #779 re-introduced `if (!nuxt.options._prepare)` guard around `buildDatabaseSchema()`, regressing PR #758 fix. This moves `buildDatabaseSchema()` outside the guard while keeping node_modules copying inside.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxthub-792](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-792/nuxthub-792?startScript=prepare) | ❌ No schema.d.mts |
| Fix | [nuxthub-792-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-792/nuxthub-792-fixed?startScript=prepare) | ✅ schema.d.mts generated |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-792 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-792
cd nuxthub-792 && pnpm i && pnpm prepare && ls .nuxt/hub/db/
```

## Verify fix

```bash
git sparse-checkout add nuxthub-792-fixed
cd ../nuxthub-792-fixed && pnpm i && pnpm prepare && ls .nuxt/hub/db/
```

The `-fixed` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.