### PR TITLE
fix(db): create package.json during prepare

### DIFF
--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -294,6 +294,8 @@ async function generateDatabaseSchema(nuxt: Nuxt, hub: ResolvedHubConfig) {
           const schemaTypes = await readFile(schemaDtsSource, 'utf-8')
           await writeFile(join(physicalDbDir, 'schema.d.mts'), schemaTypes)
         } catch {
+          // During tests, don't overwrite existing types with stub (preserves dev-generated types)
+          if (nuxt.options.test) return
           // Fallback: create a simple re-export if .d.mts doesn't exist yet
           await writeFile(join(physicalDbDir, 'schema.d.mts'), `export * from './schema.mjs'`)
         }


### PR DESCRIPTION
Closes #796
Closes #801

## Summary

1. **#796**: During `nuxt prepare`, `@nuxthub/db` was missing `package.json` and schema files → TS5090 errors. Fixed by creating stubs in `setupDatabaseClient`.

2. **#801**: Vitest with `@nuxt/test-utils` changes `buildDir`, causing schema copy to overwrite types with stubs. Fixed by skipping copy when `VITEST` env is set.

3. **DrizzleTypeError with `db.query.*`**: During `nuxt build` with `typescript.typeCheck: 'build'`, buildDir is `node_modules/.cache/nuxt/.nuxt/` where tsdown doesn't generate `.d.mts`. Fixed by falling back to `.nuxt/` for types, merging hooks to prevent race condition, and only writing stubs if files don't exist.

## Reproductions

| | Link | Expected |
|---|---|---|
| #796 Bug | [nuxthub-796](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-796/nuxthub-796?startScript=typecheck) | ❌ TS5090 error |
| #796 Fix | [nuxthub-796-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-796/nuxthub-796-fixed?startScript=typecheck) | ✅ Typecheck passes |
| DrizzleTypeError Bug | [mateusznarowski/drizzle-error](https://github.com/mateusznarowski/drizzle-error) | ❌ `db.query.users` fails |
| DrizzleTypeError Fix | [drizzle-error-797-fix](https://stackblitz.com/github/onmax/repros/tree/repro/drizzle-error-797/drizzle-error-797-fix?startScript=build) | ✅ Build passes |