### PR TITLE
fix(db): use libsql in prepare mode with cloudflare preset

### DIFF
--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -74,8 +74,8 @@ export async function resolveDatabaseConfig(nuxt: Nuxt, hub: HubConfig): Promise
         }
         break
       }
-      // Cloudflare D1 (production only - dev uses local libsql)
-      if (hub.hosting.includes('cloudflare') && !nuxt.options.dev) {
+      // Cloudflare D1 (production only - dev/prepare uses local libsql)
+      if (hub.hosting.includes('cloudflare') && !nuxt.options.dev && !nuxt.options._prepare) {
         config.driver = 'd1'
         break
       }


### PR DESCRIPTION
WIP
Closes #791

## Summary
PR #775 fixed dev mode but missed prepare mode. `nuxt prepare` runs with `dev=false, _prepare=true` → D1 driver selected → fails locally with "DB binding not found".

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxthub-791](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-791/nuxthub-791?startScript=dev) | ❌ DB binding not found |
| Fix | [nuxthub-791-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-791/nuxthub-791-fixed?startScript=dev) | ✅ Dev server starts |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-791 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-791
cd nuxthub-791 && pnpm i && pnpm dev
```

## Verify fix

```bash
git sparse-checkout add nuxthub-791-fixed
cd ../nuxthub-791-fixed && pnpm i && pnpm dev
```

The `-fixed` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.

## Related
- #772 / PR #775: Original fix added `&& !nuxt.options.dev`
- #791: Same bug but during prepare mode