### PR TITLE
fix(db): resolve Nuxt aliases in schema bundling

### DIFF
--- a/cli/commands/db/generate.mjs
+++ b/cli/commands/db/generate.mjs
@@ -1,24 +1,9 @@
-import { readFile } from 'node:fs/promises'
 import { defineCommand } from 'citty'
 import { consola } from 'consola'
 import { execa } from 'execa'
 import { join, resolve } from 'pathe'
 import { buildDatabaseSchema } from '@nuxthub/core/db'
-
-async function getTsconfigAliases(cwd) {
-  try {
-    const tsconfig = JSON.parse(await readFile(join(cwd, '.nuxt/tsconfig.json'), 'utf-8'))
-    const paths = tsconfig.compilerOptions?.paths || {}
-    const alias = {}
-    for (const [key, values] of Object.entries(paths)) {
-      const resolvedPath = key.endsWith('/*') ? values[0].replace(/\/\*$/, '') : values[0]
-      alias[key.replace(/\/\*$/, '')] = resolve(join(cwd, '.nuxt'), resolvedPath)
-    }
-    return alias
-  } catch {
-    return {}
-  }
-}
+import { getTsconfigAliases } from '../../utils/db.mjs'
 
 export default defineCommand({
   meta: {

--- a/cli/commands/db/squash.mjs
+++ b/cli/commands/db/squash.mjs
@@ -5,21 +5,7 @@ import { readFile, writeFile, rm } from 'node:fs/promises'
 import { join, resolve } from 'pathe'
 import { buildDatabaseSchema, createDrizzleClient } from '@nuxthub/core/db'
 import { sql } from 'drizzle-orm'
-
-async function getTsconfigAliases(cwd) {
-  try {
-    const tsconfig = JSON.parse(await readFile(join(cwd, '.nuxt/tsconfig.json'), 'utf-8'))
-    const paths = tsconfig.compilerOptions?.paths || {}
-    const alias = {}
-    for (const [key, values] of Object.entries(paths)) {
-      const resolvedPath = key.endsWith('/*') ? values[0].replace(/\/\*$/, '') : values[0]
-      alias[key.replace(/\/\*$/, '')] = resolve(join(cwd, '.nuxt'), resolvedPath)
-    }
-    return alias
-  } catch {
-    return {}
-  }
-}
+import { getTsconfigAliases } from '../../utils/db.mjs'
 
 export default defineCommand({
   meta: {

--- a/src/db/lib/build.ts
+++ b/src/db/lib/build.ts
@@ -80,7 +80,7 @@ export async function applyBuildTimeMigrations(nitro: Nitro, hub: ResolvedHubCon
   }
 }
 
-export async function buildDatabaseSchema(buildDir: string, { relativeDir }: { relativeDir?: string } = {}) {
+export async function buildDatabaseSchema(buildDir: string, { relativeDir, alias }: { relativeDir?: string, alias?: Record<string, string> } = {}) {
   relativeDir = relativeDir || buildDir
   const entry = join(buildDir, 'hub/db/schema.entry.ts')
   await build({
@@ -93,6 +93,7 @@ export async function buildDatabaseSchema(buildDir: string, { relativeDir }: { r
       dts: '.d.mts'
     }),
     alias: {
+      ...alias,
       'hub:db:schema': entry
     },
     platform: 'neutral',

--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -253,7 +253,7 @@ async function generateDatabaseSchema(nuxt: Nuxt, hub: ResolvedHubConfig) {
       log.info('Make sure to run `npx nuxt db generate` to generate the database migrations.')
       schemaPaths = await getSchemaPaths()
       await updateTemplates({ filter: template => template.filename.includes('hub/db/schema.entry.ts') })
-      await buildDatabaseSchema(nuxt.options.buildDir, { relativeDir: nuxt.options.rootDir })
+      await buildDatabaseSchema(nuxt.options.buildDir, { relativeDir: nuxt.options.rootDir, alias: nuxt.options.alias })
 
       // Also copy to node_modules/@nuxthub/db/ for workflow compatibility
       const physicalDbDir = join(nuxt.options.rootDir, 'node_modules', '@nuxthub', 'db')
@@ -276,7 +276,7 @@ async function generateDatabaseSchema(nuxt: Nuxt, hub: ResolvedHubConfig) {
 
   // Build schema types during prepare/dev/build
   nuxt.hooks.hookOnce('app:templatesGenerated', async () => {
-    await buildDatabaseSchema(nuxt.options.buildDir, { relativeDir: nuxt.options.rootDir })
+    await buildDatabaseSchema(nuxt.options.buildDir, { relativeDir: nuxt.options.rootDir, alias: nuxt.options.alias })
   })
 
   // Copy schema to node_modules/@nuxthub/db/ for workflow compatibility


### PR DESCRIPTION
Closes #800

## Summary
Schema files bundled via tsdown didn't resolve Nuxt aliases (`#shared`, `~`, `@`). Now passes `nuxt.options.alias` to `buildDatabaseSchema()` so tsdown can resolve them.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxthub-800](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-800/nuxthub-800?startScript=build) | ❌ Build fails |
| Fix | [nuxthub-800-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-800/nuxthub-800-fixed?startScript=build) | ✅ Build succeeds |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-800 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-800
cd nuxthub-800 && pnpm i && pnpm build
```

## Verify fix

```bash
git sparse-checkout add nuxthub-800-fixed
cd ../nuxthub-800-fixed && pnpm i && pnpm build
```

The `-fixed` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.

## Related
- https://github.com/nuxt-hub/core/issues/800