### PR TITLE
fix(blob): use variable for vercel-blob dynamic import

### DIFF
--- a/src/blob/runtime/app/composables/useMultipartUpload.ts
+++ b/src/blob/runtime/app/composables/useMultipartUpload.ts
@@ -130,7 +130,9 @@ export function useMultipartUpload(
     const start = async () => {
       const hub = useRuntimeConfig().public.hub
       if (hub.blobProvider === 'vercel-blob') {
-        return import('@vercel/blob/client').then(({ upload }) => {
+        // #809 - variable indirection to avoid Vite static analysis
+        const pkg = '@vercel/blob/client'
+        return import(/* @vite-ignore */ pkg).then(({ upload }) => {
           return upload(file.name, file, {
             access: 'public',
             multipart: true,


### PR DESCRIPTION
Closes #809

## Summary

`useMultipartUpload` fails with `fs` driver because Vite statically analyzes `import('@vercel/blob/client')` at dev time. Fix uses variable indirection so Vite's `es-module-lexer` can't extract the specifier.

## StackBlitz


|     | Link                                                                                                    | Expected    |
| --- | ------------------------------------------------------------------------------------------------------- | ----------- |
| Bug | [nuxthub-809](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-809/nuxthub-809?startScript=dev)         | ❌ Dev fails |
| Fix | [nuxthub-809-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-809/nuxthub-809-fix?startScript=dev) | ✅ Dev works |


## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-809 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-809
cd nuxthub-809 && pnpm i && pnpm dev
```

## Verify fix

```bash
git sparse-checkout add nuxthub-809-fix
cd ../nuxthub-809-fix && pnpm i && pnpm dev
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.