### PR TITLE
fix: resolve types for server auto-imports

### DIFF
--- a/src/blob/setup.ts
+++ b/src/blob/setup.ts
@@ -118,6 +118,8 @@ export const blob = createBlobStorage(createDriver(${JSON.stringify(driverOption
     }
   }
   await writeFile(join(physicalBlobDir, 'package.json'), JSON.stringify(packageJson, null, 2))
+  // Write index.d.ts for TypeScript to resolve relative directory imports
+  await writeFile(join(physicalBlobDir, 'index.d.ts'), `export * from './blob'`)
 
   // Add alias to map hub:blob to @nuxthub/blob
   nuxt.options.alias!['hub:blob'] = '@nuxthub/blob'

--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -627,6 +627,8 @@ export const db: ReturnType<typeof drizzleCore<typeof schema>>
   }
   try {
     await writeFile(join(physicalDbDir, 'package.json'), JSON.stringify(packageJson, null, 2))
+    // Write index.d.ts for TypeScript to resolve relative directory imports
+    await writeFile(join(physicalDbDir, 'index.d.ts'), `export * from './db'`)
     // Stub schema files only if they don't exist (real types written by app:templatesGenerated hook)
     const schemaPath = join(physicalDbDir, 'schema.mjs')
     const schemaDtsPath = join(physicalDbDir, 'schema.d.mts')

--- a/src/kv/setup.ts
+++ b/src/kv/setup.ts
@@ -139,6 +139,8 @@ export const kv = createStorage({
     join(physicalKvDir, 'package.json'),
     JSON.stringify(packageJson, null, 2)
   )
+  // Write index.d.ts for TypeScript to resolve relative directory imports
+  await writeFile(join(physicalKvDir, 'index.d.ts'), `export * from './kv'`)
 
   // Create hub:kv alias to @nuxthub/kv for backwards compatibility
   nuxt.options.alias!['hub:kv'] = '@nuxthub/kv'


### PR DESCRIPTION
Closes #811

## Summary
Server auto-imports (`db`, `schema`, `blob`, `kv`, `ensureBlob`) resolve to `any` because TypeScript can't resolve types from relative directory paths like `typeof import('../../node_modules/@nuxthub/db')` that nitro generates.

The fix adds `index.d.ts` files to the generated virtual packages (`@nuxthub/db`, `@nuxthub/blob`, `@nuxthub/kv`) that re-export from the main entry point, allowing TypeScript to resolve types correctly.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxthub-811](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-811/nuxthub-811?startScript=typecheck) | ❌ implicit any |
| Fix | [nuxthub-811-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-811/nuxthub-811-fix?startScript=typecheck) | ✅ types resolve |