### PR TITLE
fix(db): correct D1 migrations_dir path in wrangler.json

### DIFF
--- a/src/db/lib/client.ts
+++ b/src/db/lib/client.ts
@@ -6,7 +6,7 @@ import type { Casing } from 'drizzle-orm'
 async function createD1HttpClient(accountId: string, databaseId: string, apiToken: string, casing?: string) {
   const d1HttpDriver = async (sql: string, params: unknown[], method: string) => {
     if (method === 'values') method = 'all'
-    const response = await fetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/db/${databaseId}/raw`, {
+    const response = await fetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${databaseId}/raw`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${apiToken}`, 'Content-Type': 'application/json' },
       body: JSON.stringify({ sql, params })

--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -203,7 +203,7 @@ export async function setupDatabase(nuxt: Nuxt, hub: HubConfig, deps: Record<str
       const dbBinding = d1Databases.find(db => db.binding === 'DB')
       if (dbBinding) {
         dbBinding.migrations_table ||= '_hub_migrations'
-        dbBinding.migrations_dir ||= '.output/server/db/migrations/'
+        dbBinding.migrations_dir ||= 'db/migrations/sqlite/'
       }
     })
   }


### PR DESCRIPTION
Closes #813
Fixes same bug as #793 but in CLI code path (PR #794 only fixed `setup.ts`, missed `client.ts`)

## Summary

Two fixes:

1. **migrations_dir path** - `migrations_dir` in generated wrangler.json was set to `.output/server/db/migrations/` but wrangler resolves paths relative to its config file location (`.output/server/`). This caused doubled paths like `.output/server/.output/server/db/migrations/`. Fixed by setting the path relative to wrangler.json: `db/migrations/sqlite/`.

2. **D1 API endpoint** - `client.ts` used wrong endpoint `/d1/db/` instead of `/d1/database/`, causing POST method errors when running CLI commands against D1.

Regression introduced in #720.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxthub-813](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-813/nuxthub-813?startScript=build) | ❌ migrations_dir has wrong prefix |
| Fix | [nuxthub-813-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-813/nuxthub-813-fix?startScript=build) | ✅ migrations_dir is correct |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-813 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-813
cd nuxthub-813 && pnpm i && pnpm build
cat .output/server/wrangler.json | grep migrations_dir
```

## Verify fix

```bash
git sparse-checkout add nuxthub-813-fix
cd ../nuxthub-813-fix && pnpm i && pnpm build
cat .output/server/wrangler.json | grep migrations_dir
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.