### PR TITLE
fix(playground): fix get todos database query

### DIFF
--- a/playground/server/api/todos/index.get.ts
+++ b/playground/server/api/todos/index.get.ts
@@ -4,7 +4,7 @@ import { db } from '@nuxthub/db'
 export default eventHandler(async () => {
   // List todos for the current user
   return await db.query.todos.findMany({
-    where: eq(schema.todos.completed, false),
+    where: eq(schema.todos.completed, 0),
     orderBy: [desc(schema.todos.createdAt)]
   })
 })


### PR DESCRIPTION
Change comparing argument in get query to use number, which is defined as numeric column type in schemas. Check:

- [schema.sqlite.ts](https://github.com/nuxt-hub/core/blob/main/playground/server/db/schema.sqlite.ts)
- [schema.mysql.ts](https://github.com/nuxt-hub/core/blob/main/playground/server/db/schema.mysql.ts)
- [schema.postgresql.ts](https://github.com/nuxt-hub/core/blob/main/playground/server/db/schema.postgresql.ts)

I thing for some weird reason, it works in default `sqlite`, but it fails in `postgresql` (at least in default `pglite` driver). Anyways, I believe it to be good change to work with all the schemas.

Fixes #818 