### PR TITLE
fix(docs): make formatting in db migrate command usage consistant

### DIFF
--- a/docs/content/docs/2.database/cli.md
+++ b/docs/content/docs/2.database/cli.md
@@ -43,7 +43,6 @@ Apply database migrations to the database.
 USAGE db migrate [OPTIONS]
 
 OPTIONS
-
           --cwd    The directory to run the command in.
        --dotenv    Point to another .env file to load.
   -v, --verbose    Show verbose output.


### PR DESCRIPTION
Removed empty line to match other cli usage docs.