### PR TITLE
fix(db): resolve @nuxthub/db from rootDir for pnpm workspaces

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,3 +1,6 @@
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { logger } from '@nuxt/kit'
 import type { Nuxt } from 'nuxt/schema'
 import type { HubConfig, ResolvedDatabaseConfig } from '@nuxthub/core'
@@ -20,7 +23,11 @@ async function launchDrizzleStudio(nuxt: Nuxt, hub: HubConfig) {
 
   try {
     const { dialect, driver, connection } = dbConfig
-    const { schema } = await import(nuxt.options.alias!['hub:db'] as string)
+    const dbEntry = resolve(nuxt.options.rootDir, 'node_modules', '@nuxthub', 'db', 'db.mjs')
+    if (!existsSync(dbEntry)) {
+      throw new Error(`Cannot find @nuxthub/db at ${dbEntry}. Run \`nuxi prepare\` to generate it.`)
+    }
+    const { schema } = await import(pathToFileURL(dbEntry).href)
 
     // Launch Drizzle Studio based on dialect and driver
     if (dialect === 'postgresql') {


### PR DESCRIPTION
Closes #826

In pnpm workspaces, `@nuxthub/db` can't be resolved when launching Drizzle Studio because the alias-based `import()` resolves from the pnpm store path instead of the project's `rootDir` where the package is generated.

Uses absolute path resolution from `rootDir` + `existsSync` guard with actionable error message.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxthub-826](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-826/nuxthub-826?startScript=dev) | ❌ `Cannot find module '@nuxthub/db'` |
| Fix | [nuxthub-826-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-826/nuxthub-826-fix?startScript=dev) | ✅ Drizzle Studio launches |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-826 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-826
cd nuxthub-826 && pnpm i && pnpm --filter web dev
```

## Verify fix

```bash
git sparse-checkout add nuxthub-826-fix
cd ../nuxthub-826-fix && pnpm i && pnpm --filter web dev
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.

## Related
- https://github.com/nuxt-hub/core/issues/826