### PR TITLE
fix: fix incorrect license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pnpm test:watch
 
 ## 📄 License
 
-[Apache 2.0](./LICENSE)
+[MIT](./LICENSE)
 
 <!-- Badges -->
 [npm-version-src]: https://img.shields.io/npm/v/@nuxthub/core/latest.svg?style=flat&colorA=020420&colorB=00DC82


### PR DESCRIPTION
The README listed the license as Apache 2.0, but the LICENSE file shows it's actually MIT.

This PR updates the README to reflect the correct license.