### PR TITLE
feat(db): add `hub.db.applyMigrationsDuringDev: boolean` option

### DIFF
--- a/docs/content/docs/2.database/1.index.md
+++ b/docs/content/docs/2.database/1.index.md
@@ -328,7 +328,7 @@ You can find your Neon connection string in the [Neon dashboard](https://console
 
 ### Docker/Kubernetes Deployments
 
-Build container images without database credentials by deferring environment resolution to runtime. Set the driver explicitly and disable build-time migrations:
+Build container images without database credentials by deferring environment resolution to runtime. Set the driver explicitly and disable automatic migrations during build and dev:
 
 ::tabs{sync="database-dialect"}
   :::tabs-item{label="SQLite" icon="i-simple-icons-sqlite"}
@@ -338,7 +338,8 @@ Build container images without database credentials by deferring environment res
       db: {
         dialect: 'sqlite',
         driver: 'libsql',
-        applyMigrationsDuringBuild: false
+        applyMigrationsDuringBuild: false,
+        applyMigrationsDuringDev: false
       }
     }
   })
@@ -351,7 +352,8 @@ Build container images without database credentials by deferring environment res
       db: {
         dialect: 'postgresql',
         driver: 'postgres-js', // or 'neon-http'
-        applyMigrationsDuringBuild: false
+        applyMigrationsDuringBuild: false,
+        applyMigrationsDuringDev: false
       }
     }
   })
@@ -364,7 +366,8 @@ Build container images without database credentials by deferring environment res
       db: {
         dialect: 'mysql',
         driver: 'mysql2',
-        applyMigrationsDuringBuild: false
+        applyMigrationsDuringBuild: false,
+        applyMigrationsDuringDev: false
       }
     }
   })

--- a/docs/content/docs/2.database/4.migrations.md
+++ b/docs/content/docs/2.database/4.migrations.md
@@ -74,13 +74,14 @@ For Cloudflare D1, migrations cannot run during build since there is no database
 ::
 
 ::note
-To disable automatic migrations during `nuxt build`, you can set the `applyMigrationsDuringBuild` option to `false`:
+To disable automatic migrations during `nuxt build`, you can set the `applyMigrationsDuringBuild` option to `false`. To disable automatic migrations during `nuxt dev`, set `applyMigrationsDuringDev` to `false` (useful when running dev with production env vars):
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   hub: {
     db: {
-      applyMigrationsDuringBuild: false
+      applyMigrationsDuringBuild: false,
+      applyMigrationsDuringDev: false
     }
   }
 })

--- a/src/db/runtime/plugins/migrations.dev.ts
+++ b/src/db/runtime/plugins/migrations.dev.ts
@@ -7,6 +7,7 @@ export default defineNitroPlugin(async () => {
 
   const hub = useRuntimeConfig().hub as ResolvedHubConfig
   if (!hub.db) return
+  if (!hub.db.applyMigrationsDuringDev) return
 
   let db
   try {

--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -45,7 +45,8 @@ export async function resolveDatabaseConfig(nuxt: Nuxt, hub: HubConfig): Promise
   config = defu(config, {
     migrationsDirs: getLayerDirectories(nuxt).map(layer => join(layer.server, 'db/migrations')),
     queriesPaths: [],
-    applyMigrationsDuringBuild: true
+    applyMigrationsDuringBuild: true,
+    applyMigrationsDuringDev: true
   })
 
   switch (config.dialect) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -192,6 +192,12 @@ export type DatabaseConfig = {
    */
   applyMigrationsDuringBuild?: boolean
   /**
+   * Set `false` to disable applying database migrations during development (`nuxt dev`).
+   *
+   * @default true
+   */
+  applyMigrationsDuringDev?: boolean
+  /**
    * MySQL mode for Drizzle ORM relational queries.
    * Only applicable when dialect is 'mysql'.
    *
@@ -227,6 +233,7 @@ export type ResolvedDatabaseConfig = DatabaseConfig & {
   migrationsDirs: string[]
   queriesPaths: string[]
   applyMigrationsDuringBuild: boolean
+  applyMigrationsDuringDev: boolean
   casing?: 'snake_case' | 'camelCase'
   replicas?: string[]
 }

--- a/test/database.config.test.ts
+++ b/test/database.config.test.ts
@@ -61,7 +61,8 @@ describe('resolveDatabaseConfig', () => {
         connection: {
           url: 'file:/tmp/test-hub/db/sqlite.db'
         },
-        applyMigrationsDuringBuild: true
+        applyMigrationsDuringBuild: true,
+        applyMigrationsDuringDev: true
       })
       expect(result).not.toBe(false)
       if (result !== false) {
@@ -471,6 +472,21 @@ describe('resolveDatabaseConfig', () => {
       }
     })
 
+    it('should respect custom applyMigrationsDuringDev', async () => {
+      const nuxt = createMockNuxt()
+      const hub = createBaseHubConfig({
+        dialect: 'sqlite',
+        applyMigrationsDuringDev: false
+      })
+
+      const result = await resolveDatabaseConfig(nuxt, hub)
+
+      expect(result).not.toBe(false)
+      if (result !== false) {
+        expect(result.applyMigrationsDuringDev).toBe(false)
+      }
+    })
+
     it('should handle multiple layers for migrationsDirs', async () => {
       const nuxt = createMockNuxt([
         { config: { srcDir: '/app', rootDir: '/app', serverDir: '/app/server' } },
@@ -687,6 +703,7 @@ describe('resolveDatabaseConfig', () => {
       expect(result).not.toBe(false)
       if (result !== false) {
         expect(result.applyMigrationsDuringBuild).toBe(false)
+        expect(result.applyMigrationsDuringDev).toBe(true)
       }
     })
   })


### PR DESCRIPTION
Closes #836

Summary of what was implemented (everything is analogous to existing `applyMigrationsDuringBuild`):

1. Types

- Added `applyMigrationsDuringDev?: boolean` to `DatabaseConfig` with JSDoc (@default true).
- Added `applyMigrationsDuringDev: boolea`n to `ResolvedDatabaseConfig`.

1. Default

- Set default `applyMigrationsDuringDev: true` in the defu config in `resolveDatabaseConfig`.

1. Dev plugin

- Added early return: if (`!hub.db.applyMigrationsDuringDev`) return so migrations are skipped when the option is false.

1. Tests

- Included `applyMigrationsDuringDev: true` in the default SQLite test.
- Added “should respect custom applyMigrationsDuringDev” test for `applyMigrationsDuringDev: false`.
- In the D1 test, asserted `applyMigrationsDuringDev` stays true (D1 does not force it to false).

1. Docs

- `docs/content/docs/2.database/4.migrations.md`: Extended the note to describe `applyMigrationsDuringDev` and showed both options in the example.
- `docs/content/docs/2.database/1.index.md`: In the Docker/Kubernetes section, updated the intro and added `applyMigrationsDuringDev: false` to the SQLite, PostgreSQL, and MySQL examples.

All tests pass, and there are no linter errors.