### PR TITLE
fix(db): respect explicit libsql driver on Cloudflare

### DIFF
--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -74,14 +74,14 @@ export async function resolveDatabaseConfig(nuxt: Nuxt, hub: HubConfig): Promise
         }
         break
       }
+      // User explicitly set libsql (e.g. Turso with inline config)
+      if (userExplicitLibsql) {
+        config.connection = defu(config.connection, { url: '' })
+        break
+      }
       // Cloudflare D1 (production only - dev/prepare uses local libsql)
       if (hub.hosting.includes('cloudflare') && !nuxt.options.dev && !nuxt.options._prepare) {
         config.driver = 'd1'
-        break
-      }
-      // User explicitly set libsql without env vars - allow lazy resolution at runtime
-      if (userExplicitLibsql) {
-        config.connection = defu(config.connection, { url: '' })
         break
       }
       config.driver ||= 'libsql'


### PR DESCRIPTION
Closes #841

## Summary

NuxtHub forces `driver: 'd1'` on Cloudflare production builds, ignoring user's explicit `driver: 'libsql'` with inline connection config (e.g. Turso with custom env var names).

The Cloudflare D1 override ran **before** the `userExplicitLibsql` check, so it always won. Reordered the priority so explicit `driver: 'libsql'` is respected.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxthub-841](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-841/nuxthub-841?startScript=verify) | FAIL: d1 forced |
| Fix | [nuxthub-841-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-841/nuxthub-841-fix?startScript=verify) | PASS: libsql respected |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-841 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-841
cd nuxthub-841 && pnpm i && pnpm verify
```

## Verify fix

```bash
git sparse-checkout add nuxthub-841-fix
cd ../nuxthub-841-fix && pnpm i && pnpm verify
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.

## Related
- https://github.com/nuxt-hub/core/issues/841