### PR TITLE
fix(db): pass driver options to postgres-js

### DIFF
--- a/src/db/lib/client.ts
+++ b/src/db/lib/client.ts
@@ -32,8 +32,6 @@ async function createD1HttpClient(accountId: string, databaseId: string, apiToke
  */
 export async function createDrizzleClient(config: ResolvedDatabaseConfig, hubDir: string) {
   const { driver, connection, casing } = config
-  let client
-
   let pkg = ''
   if (driver === 'd1' || driver === 'd1-http') {
     // Get credentials from config or env vars
@@ -45,14 +43,9 @@ export async function createDrizzleClient(config: ResolvedDatabaseConfig, hubDir
     }
     return createD1HttpClient(accountId, databaseId, apiToken, casing)
   } else if (driver === 'postgres-js') {
-    const clientPkg = 'postgres'
-    const { default: postgres } = await import(clientPkg)
-    client = postgres(connection.url, {
-      onnotice: () => {}
-    })
     pkg = 'drizzle-orm/postgres-js'
     const { drizzle } = await import(pkg)
-    return drizzle({ client, casing })
+    return drizzle({ connection: { ...connection, onnotice: () => {} }, casing })
   } else if (driver === 'neon-http') {
     const clientPkg = '@neondatabase/serverless'
     const { neon } = await import(clientPkg)


### PR DESCRIPTION
Closes #840

## Summary
`connection` options like `prepare: false` are silently dropped when creating postgres-js clients. Only `url` is extracted; everything else is discarded. Breaks Supabase transaction pooler (port 6543) which requires `prepare: false`.

drizzle-orm already forwards extra connection fields to `postgres()` via `const { url, ...config } = connection; postgres(url, config)`. For the simple case (no replicas), we now let drizzle handle client creation. For replicas/lazy init, we strip only `url` and spread the rest.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxthub-840](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-840/nuxthub-840?startScript=build) | `prepare` missing from postgres() call |
| Fix | [nuxthub-840-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-840/nuxthub-840-fix?startScript=build) | `prepare: false` present |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-840 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-840
cd nuxthub-840 && pnpm i && pnpm build
# Check node_modules/@nuxthub/db/db.mjs — prepare is missing
```

## Verify fix

```bash
git sparse-checkout add nuxthub-840-fix
cd ../nuxthub-840-fix && pnpm i && pnpm build
# Check node_modules/@nuxthub/db/db.mjs — prepare: false is present
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.