### PR TITLE
fix(docs): update migration handling for Cloudflare D1

### DIFF
--- a/docs/content/docs/6.guides/3.ci-cd.md
+++ b/docs/content/docs/6.guides/3.ci-cd.md
@@ -90,6 +90,20 @@ Unlike PostgreSQL or MySQL, where build-time migrations work because the databas
 
 Run migrations before deployment using Wrangler or the NuxtHub CLI.
 
+::warning
+If you applied migrations with NuxtHub before v0.10 and you use Cloudflare D1, some rows in `_hub_migrations` may be missing the `.sql` suffix. Wrangler requires `.sql` in order to recognize the migration files.
+::
+
+Fix: Update the migration names in the `_hub_migrations` table to include the `.sql` suffix.
+
+```sql
+-- Preview affected rows
+SELECT id, name FROM _hub_migrations WHERE name NOT LIKE '%.sql';
+
+-- Append .sql
+UPDATE _hub_migrations SET name = name || '.sql' WHERE name NOT LIKE '%.sql';
+```
+
 #### 1. Disable Build-Time Migrations
 
 ```ts [nuxt.config.ts]
@@ -119,7 +133,7 @@ Configure your `wrangler.jsonc` to use NuxtHub's migration table and output dire
     "binding": "DB",
     "database_id": "<database-id>",
     "migrations_table": "_hub_migrations",
-    "migrations_dir": ".output/server/db/migrations/"
+    "migrations_dir": ".output/server/db/migrations/sqlite/"
   }]
 }
 ```
@@ -145,19 +159,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      # Run migrations BEFORE the build step
+      - name: Build
+        run: pnpm build
+
       - name: Apply D1 Migrations
         run: npx wrangler d1 migrations apply <database-name> --remote
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-
-      - name: Build
-        run: pnpm build
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy
         run: npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          
 ```
 
 **Option B: Using `nuxt db migrate`**


### PR DESCRIPTION
Updates the Cloudflare D1 section in the [CI/CD documentation](https://hub.nuxt.com/docs/guides/ci-cd#d1-migrations-in-cicd)  with corrected D1 database apply migration configurations

changes made:
- Added note  for migration names compatibility issue for users upgrading from pre v0.10 NuxtHub version. 
Previous migration names in the `_hub_migrations` table may lack the `.sql` extension. Wrangler requires `.sql` in order to 			recognize the migration files
- Corrected `migrations_dir` path to include dialect
 `.output/server/db/migrations/` ->  `.output/server/db/migrations/sqlite/`
- Update workflow to run step Apply D1 Migrations after build step and include CLOUDFLARE_ACCOUNT_ID env variable 

I had these issues myself and these were the changes needed to be able to make the D1 migrations work.