### PR TITLE
feat(cli): support db generate --dialect arg

### DIFF
--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -39,6 +39,8 @@ export { db, schema }
  * Resolve database configuration from string or object format
  */
 export async function resolveDatabaseConfig(nuxt: Nuxt, hub: HubConfig): Promise<ResolvedDatabaseConfig | false> {
+  // Env explicitly set db. Used by cli db generate command
+  if(process.env.NUXT_HUB_DB) hub.db = process.env.NUXT_HUB_DB
   if (!hub.db) return false
 
   let config = typeof hub.db === 'string' ? { dialect: hub.db } : hub.db

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,6 +3,7 @@ import type { FSDriverOptions } from '@nuxthub/core/blob/drivers/fs'
 import type { S3DriverOptions } from '@nuxthub/core/blob/drivers/s3'
 import type { VercelDriverOptions } from '@nuxthub/core/blob/drivers/vercel-blob'
 import type { CloudflareDriverOptions } from '@nuxthub/core/blob/drivers/cloudflare-r2'
+import type { Config as DrizzleConfig } from "drizzle-kit"
 
 export interface HubConfig {
   blob: boolean | BlobConfig
@@ -224,6 +225,15 @@ export type DatabaseConfig = {
    * @see https://orm.drizzle.team/docs/read-replicas
    */
   replicas?: string[]
+  /**
+   * Drizzle config that will be passed down to the generated drizzle.config.ts
+   * 
+   * @see https://orm.drizzle.team/docs/drizzle-config-file
+   */
+  drizzle?: Pick<
+    DrizzleConfig,
+    "entities" | "schemaFilter" | "tablesFilter" | "extensionsFilters"
+  >;
 }
 
 export type ResolvedDatabaseConfig = DatabaseConfig & {


### PR DESCRIPTION
Resolves https://github.com/nuxt-hub/core/issues/845

Adds --dialect arg to db generate command.
Added an env override to hub.db so if NUXT_HUB_DB is defined it takes priority over otherwise configs.

Env overriding could be problematic, but currently the best solution afaik.
