### PR TITLE
fix: resolve module add exports error

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
   "exports": {
     ".": {
       "types": "./dist/types.d.mts",
-      "import": "./dist/module.mjs"
+      "import": "./dist/module.mjs",
+      "default": "./dist/module.mjs"
     },
+    "./package.json": "./package.json",
     "./blob": {
       "types": "./dist/blob/lib/index.d.ts",
       "import": "./dist/blob/lib/index.mjs"

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -1,0 +1,22 @@
+import { readFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+describe('package exports', () => {
+  it('defines resolver-compatible root exports', async () => {
+    const packageJsonPath = new URL('../package.json', import.meta.url)
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+      exports: Record<string, any>
+    }
+
+    expect(packageJson.exports['.']?.default).toBe('./dist/module.mjs')
+    expect(packageJson.exports['./package.json']).toBe('./package.json')
+  })
+
+  it('can be resolved with require.resolve', () => {
+    const require = createRequire(import.meta.url)
+    const resolved = require.resolve('@nuxthub/core').replace(/\\/g, '/')
+
+    expect(resolved.endsWith('/dist/module.mjs')).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #857.

`npx nuxi module add hub` installs `@nuxthub/core`, then fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Why it errors
`nuxi module add` uses `nypm` with `installPeerDependencies: true`, and that code path resolves the installed package with `require.resolve(pkgName)`.
Our root export only exposed `import`, so `require.resolve('@nuxthub/core')` failed.

behavior originates from Nuxt CLI [`nuxt/cli` PR #654](https://github.com/nuxt/cli/pull/654) (`installPeerDependencies` in module add flow)

## Regression test

If we want to add broader export regression coverage, Antfu starter uses export manifest snapshots:
- [starter-ts `test/exports.test.ts`](https://github.com/antfu/starter-ts/blob/main/test/exports.test.ts)
