### PR TITLE
fix(db): skip hyperdrive build migrations

### DIFF
--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -101,12 +101,12 @@ export async function resolveDatabaseConfig(nuxt: Nuxt, hub: HubConfig): Promise
       break
     }
     case 'postgresql': {
-      // Cloudflare Hyperdrive with explicit hyperdriveId
-      if (hub.hosting.includes('cloudflare') && config.connection?.hyperdriveId && !config.driver) {
-        config.driver = 'postgres-js'
+      config.connection = defu(config.connection, { url: process.env.POSTGRES_URL || process.env.POSTGRESQL_URL || process.env.DATABASE_URL || '' })
+      if (hub.hosting.includes('cloudflare') && config.connection?.hyperdriveId && !config.connection.url && (!config.driver || config.driver === 'postgres-js')) {
+        config.driver ||= 'postgres-js'
+        config.applyMigrationsDuringBuild = false
         break
       }
-      config.connection = defu(config.connection, { url: process.env.POSTGRES_URL || process.env.POSTGRESQL_URL || process.env.DATABASE_URL || '' })
       // Only error at build time if migrations need to run
       if (config.applyMigrationsDuringBuild && config.driver && ['neon-http', 'postgres-js'].includes(config.driver) && !config.connection.url) {
         throw new Error(`\`${config.driver}\` driver requires \`DATABASE_URL\`, \`POSTGRES_URL\`, or \`POSTGRESQL_URL\` environment variable when \`applyMigrationsDuringBuild\` is enabled`)
@@ -121,13 +121,13 @@ export async function resolveDatabaseConfig(nuxt: Nuxt, hub: HubConfig): Promise
       break
     }
     case 'mysql': {
-      // Cloudflare Hyperdrive with explicit hyperdriveId
-      if (hub.hosting.includes('cloudflare') && config.connection?.hyperdriveId && !config.driver) {
-        config.driver = 'mysql2'
+      config.connection = defu(config.connection, { uri: process.env.MYSQL_URL || process.env.DATABASE_URL || '' })
+      if (hub.hosting.includes('cloudflare') && config.connection?.hyperdriveId && !config.connection.uri) {
+        config.driver ||= 'mysql2'
+        config.applyMigrationsDuringBuild = false
         break
       }
       config.driver ||= 'mysql2'
-      config.connection = defu(config.connection, { uri: process.env.MYSQL_URL || process.env.DATABASE_URL || '' })
       // Only error at build time if migrations need to run
       if (config.applyMigrationsDuringBuild && !config.connection.uri) {
         throw new Error('MySQL requires DATABASE_URL or MYSQL_URL environment variable when `applyMigrationsDuringBuild` is enabled')

--- a/test/database.config.test.ts
+++ b/test/database.config.test.ts
@@ -340,6 +340,71 @@ describe('resolveDatabaseConfig', () => {
         applyMigrationsDuringBuild: false
       })
     })
+
+    it('should disable build migrations for Cloudflare Hyperdrive without a direct URL', async () => {
+      const nuxt = createMockNuxt()
+      const hub = createBaseHubConfig({
+        dialect: 'postgresql',
+        connection: {
+          hyperdriveId: 'hyperdrive-id'
+        }
+      })
+      hub.hosting = 'cloudflare'
+
+      const result = await resolveDatabaseConfig(nuxt, hub)
+
+      expect(result).toMatchObject({
+        dialect: 'postgresql',
+        driver: 'postgres-js',
+        connection: {
+          hyperdriveId: 'hyperdrive-id',
+          url: ''
+        },
+        applyMigrationsDuringBuild: false
+      })
+    })
+
+    it('should keep build migrations enabled for Cloudflare Hyperdrive when DATABASE_URL is set', async () => {
+      process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/db'
+
+      const nuxt = createMockNuxt()
+      const hub = createBaseHubConfig({
+        dialect: 'postgresql',
+        connection: {
+          hyperdriveId: 'hyperdrive-id'
+        }
+      })
+      hub.hosting = 'cloudflare'
+
+      const result = await resolveDatabaseConfig(nuxt, hub)
+
+      expect(result).toMatchObject({
+        dialect: 'postgresql',
+        driver: 'postgres-js',
+        connection: {
+          hyperdriveId: 'hyperdrive-id',
+          url: 'postgresql://user:pass@localhost:5432/db'
+        },
+        applyMigrationsDuringBuild: true
+      })
+    })
+
+    it('should still require a direct URL for explicit neon-http with Hyperdrive', async () => {
+      const nuxt = createMockNuxt()
+      const hub = createBaseHubConfig({
+        dialect: 'postgresql',
+        driver: 'neon-http',
+        connection: {
+          hyperdriveId: 'hyperdrive-id'
+        },
+        applyMigrationsDuringBuild: true
+      })
+      hub.hosting = 'cloudflare'
+
+      await expect(resolveDatabaseConfig(nuxt, hub)).rejects.toThrow(
+        '`neon-http` driver requires `DATABASE_URL`, `POSTGRES_URL`, or `POSTGRESQL_URL` environment variable when `applyMigrationsDuringBuild` is enabled'
+      )
+    })
   })
 
   describe('MySQL dialect', () => {
@@ -401,6 +466,29 @@ describe('resolveDatabaseConfig', () => {
       expect(result).toMatchObject({
         dialect: 'mysql',
         driver: 'mysql2',
+        applyMigrationsDuringBuild: false
+      })
+    })
+
+    it('should disable build migrations for Cloudflare Hyperdrive MySQL without a direct URL', async () => {
+      const nuxt = createMockNuxt()
+      const hub = createBaseHubConfig({
+        dialect: 'mysql',
+        connection: {
+          hyperdriveId: 'hyperdrive-id'
+        }
+      })
+      hub.hosting = 'cloudflare'
+
+      const result = await resolveDatabaseConfig(nuxt, hub)
+
+      expect(result).toMatchObject({
+        dialect: 'mysql',
+        driver: 'mysql2',
+        connection: {
+          hyperdriveId: 'hyperdrive-id',
+          uri: ''
+        },
         applyMigrationsDuringBuild: false
       })
     })


### PR DESCRIPTION
Closes #867

## Summary

Cloudflare Hyperdrive bindings are only available at runtime, but NuxtHub still tried to run build-time migrations for Hyperdrive-only PostgreSQL/MySQL configs when `applyMigrationsDuringBuild` was enabled.

This PR keeps the Hyperdrive runtime binding path unchanged and fixes one specific bug:
- Hyperdrive-only PostgreSQL/MySQL configs no longer fail `nuxt build` when no direct build-time connection URL is available.

It does **not** make Hyperdrive-only configs run migrations during build. That follow-up is tracked in #869.

## Behavior after this change

- If `connection.hyperdriveId` is configured on Cloudflare and no direct build-time URL is available, NuxtHub preserves the Hyperdrive binding and skips build-time migrations.
- If a direct build-time URL is also available (`DATABASE_URL`, `POSTGRES_URL`, `POSTGRESQL_URL`, or `MYSQL_URL`), build-time migrations still run.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxthub-867](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-867/nuxthub-867?startScript=build) | ❌ Build reaches database migrations and fails |
| Fix | [nuxthub-867-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-867/nuxthub-867-fix?startScript=build) | ✅ Build succeeds, preserves Hyperdrive binding, and skips build-time migrations |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-867 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-867
cd nuxthub-867 && pnpm i && pnpm build
```

## Verify fix

```bash
git sparse-checkout add nuxthub-867-fix
cd ../nuxthub-867-fix && pnpm i && pnpm build
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally and verifies all of the following:
- the build succeeds,
- the Hyperdrive binding is present in `.output/server/wrangler.json`,
- build-time migrations are not executed when only `connection.hyperdriveId` is available.
