### PR TITLE
fix(cloudflare): support config-defined bindings in dev

### DIFF
--- a/src/hosting/cloudflare.ts
+++ b/src/hosting/cloudflare.ts
@@ -1,4 +1,4 @@
-import { writeFile, readFile } from 'node:fs/promises'
+import { writeFile, readFile, mkdir } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { join } from 'pathe'
 import { defu } from 'defu'
@@ -36,8 +36,32 @@ export function setupCloudflare(nuxt: Nuxt, hub: HubConfig) {
     })
   }
 
-  // Setup wrangler.json processing (environment flattening + feature hooks)
-  if (nuxt.options.dev || nuxt.options._prepare) {
+  if (nuxt.options._prepare) {
+    return
+  }
+
+  if (nuxt.options.dev) {
+    const configPath = join(nuxt.options.buildDir, 'wrangler.json')
+    nuxt.options.nitro.cloudflare.dev ||= {}
+    nuxt.options.nitro.cloudflare.dev.configPath ||= configPath
+
+    nuxt.hook('nitro:config', async (nitroConfig) => {
+      nitroConfig.cloudflare ||= {}
+      nitroConfig.cloudflare.dev ||= {}
+      nitroConfig.cloudflare.dev.configPath ||= configPath
+
+      const wranglerConfig = nitroConfig.cloudflare.wrangler || nuxt.options.nitro.cloudflare?.wrangler
+      if (!wranglerConfig) {
+        return
+      }
+
+      await mkdir(nuxt.options.buildDir, { recursive: true })
+      await writeFile(configPath, JSON.stringify({
+        compatibility_date: resolveCloudflareCompatibilityDate(nuxt),
+        ...wranglerConfig
+      }, null, 2), 'utf-8')
+    })
+
     return
   }
 
@@ -45,6 +69,15 @@ export function setupCloudflare(nuxt: Nuxt, hub: HubConfig) {
     const cloudflareEnv = process.env.CLOUDFLARE_ENV
     await processWranglerConfigFile(nuxt, cloudflareEnv)
   })
+}
+
+function resolveCloudflareCompatibilityDate(nuxt: Nuxt) {
+  const compatibilityDate = nuxt.options.compatibilityDate
+  if (typeof compatibilityDate === 'string') {
+    return compatibilityDate
+  }
+
+  return compatibilityDate.cloudflare || compatibilityDate.default
 }
 
 /**

--- a/src/module.ts
+++ b/src/module.ts
@@ -87,7 +87,7 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.nitro.experimental = nuxt.options.nitro.experimental || {}
     nuxt.options.nitro.experimental.asyncContext = true
 
-    if (!nuxt.options.dev && hub.hosting.includes('cloudflare')) {
+    if (hub.hosting.includes('cloudflare')) {
       setupCloudflare(nuxt, hub)
     }
 

--- a/test/fixtures/wrangler/nuxt.config.ts
+++ b/test/fixtures/wrangler/nuxt.config.ts
@@ -3,6 +3,10 @@ import { defineNuxtConfig } from 'nuxt/config'
 export default defineNuxtConfig({
   extends: ['../basic'],
   modules: ['../../../src/module'],
+  compatibilityDate: '2025-07-15',
+  nitro: {
+    preset: 'cloudflare_module'
+  },
   hub: {
     blob: { driver: 'cloudflare-r2', bucketName: 'test-bucket', binding: 'BLOB' },
     kv: { driver: 'cloudflare-kv-binding', namespaceId: 'test-kv-id', binding: 'KV' },

--- a/test/wrangler.test.ts
+++ b/test/wrangler.test.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { setup, useTestContext } from '@nuxt/test-utils'
@@ -23,5 +25,20 @@ describe('wrangler bindings e2e', async () => {
     expect(wrangler?.kv_namespaces).toContainEqual({ binding: 'KV', id: 'test-kv-id' })
     expect(wrangler?.kv_namespaces).toContainEqual({ binding: 'CACHE', id: 'test-cache-id' })
     expect(wrangler?.d1_databases).toContainEqual({ binding: 'DB', database_id: 'test-db-id' })
+  })
+
+  it('should write a dev wrangler config from hub bindings', async () => {
+    const { nuxt } = useTestContext()
+    const configPath = nuxt?.options.nitro.cloudflare?.dev?.configPath
+
+    expect(configPath).toBeTruthy()
+    expect(existsSync(configPath!)).toBe(true)
+
+    const config = JSON.parse(await readFile(configPath!, 'utf8'))
+    expect(config.compatibility_date).toBe('2025-07-15')
+    expect(config.r2_buckets).toContainEqual({ binding: 'BLOB', bucket_name: 'test-bucket' })
+    expect(config.kv_namespaces).toContainEqual({ binding: 'KV', id: 'test-kv-id' })
+    expect(config.kv_namespaces).toContainEqual({ binding: 'CACHE', id: 'test-cache-id' })
+    expect(config.d1_databases).toContainEqual({ binding: 'DB', database_id: 'test-db-id' })
   })
 })


### PR DESCRIPTION
Closes #870

## Summary
NuxtHub already generates Cloudflare bindings from `nuxt.config.ts`, but in dev mode Nitro's Cloudflare proxy only reads bindings from a physical Wrangler config file.

This change runs NuxtHub's Cloudflare setup in dev and writes a temporary `.nuxt/wrangler.json` from `nitro.cloudflare.wrangler`, then points Nitro's Cloudflare dev emulation at that file.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxthub-870](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-870/nuxthub-870?startScript=dev) | ❌ `pnpm dev` fails with `DB binding not found` |
| Fix | [nuxthub-870-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-870/nuxthub-870-fix?startScript=dev) | ✅ `pnpm dev` starts without the D1 binding error |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-870 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-870
cd nuxthub-870 && pnpm i && pnpm dev
```

## Verify fix

```bash
git sparse-checkout add nuxthub-870-fix
cd ../nuxthub-870-fix && pnpm i && pnpm dev
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.

## Tests

```bash
pnpm vitest run test/wrangler.test.ts
```

## Related
- [nuxt-hub/core#870](https://github.com/nuxt-hub/core/issues/870)
