### PR TITLE
fix(db): resolve extensions in tsconfig aliases

### DIFF
--- a/cli/utils/db.mjs
+++ b/cli/utils/db.mjs
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
 import { join, resolve } from 'pathe'
 import { createStorage } from 'unstorage'
 import fsDriver from 'unstorage/drivers/fs'
@@ -34,6 +35,14 @@ export async function getNextMigrationNumber() {
   return (lastSequentialMigrationNumber + 1).toString().padStart(4, '0')
 }
 
+function resolveWithExtensions(path) {
+  if (existsSync(path)) return path
+  for (const ext of ['.mjs', '.js', '.ts', '.mts', '.json']) {
+    if (existsSync(path + ext)) return path + ext
+  }
+  return path
+}
+
 export async function getTsconfigAliases(cwd) {
   try {
     const tsconfig = JSON.parse(await readFile(join(cwd, '.nuxt/tsconfig.json'), 'utf-8'))
@@ -41,7 +50,7 @@ export async function getTsconfigAliases(cwd) {
     const alias = {}
     for (const [key, values] of Object.entries(paths)) {
       const resolvedPath = key.endsWith('/*') ? values[0].replace(/\/\*$/, '') : values[0]
-      alias[key.replace(/\/\*$/, '')] = resolve(join(cwd, '.nuxt'), resolvedPath)
+      alias[key.replace(/\/\*$/, '')] = resolveWithExtensions(resolve(join(cwd, '.nuxt'), resolvedPath))
     }
     return alias
   } catch {


### PR DESCRIPTION
Closes #880

## Summary
`getTsconfigAliases()` reads `.nuxt/tsconfig.json` paths which strip file extensions. Alias resolves to e.g. `.nuxt/better-auth/schema` but file is `schema.mjs`. Rolldown fails.

Now tries common extensions (`.mjs`, `.js`, `.ts`, `.mts`, `.json`) when the extensionless path doesn't exist.

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxthub-alias-extensions](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-alias-extensions/nuxthub-alias-extensions?startScript=generate) | ❌ Build fails |
| Fix | [nuxthub-alias-extensions-fix](https://stackblitz.com/github/onmax/repros/tree/repro/nuxthub-alias-extensions/nuxthub-alias-extensions-fix?startScript=generate) | ✅ Migration generated |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxthub-alias-extensions https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxthub-alias-extensions
cd nuxthub-alias-extensions && pnpm i && npx nuxt db generate
```

## Verify fix

```bash
git sparse-checkout add nuxthub-alias-extensions-fix
cd ../nuxthub-alias-extensions-fix && pnpm i && npx nuxt db generate
```