### PR TITLE
fix(sql): use dialect-aware identifier quoting in CLI commands

### DIFF
--- a/cli/commands/db/drop-all.mjs
+++ b/cli/commands/db/drop-all.mjs
@@ -110,8 +110,8 @@ export default defineCommand({
         for (const schema of schemas) {
           try {
             consola.debug(`Dropping schema \`${schema}\`...`)
-            await db[execute](sql.raw(`DROP SCHEMA "${schema}" CASCADE;`))
-            await db[execute](sql.raw(`CREATE SCHEMA "${schema}";`))
+            await db[execute](sql.raw(`DROP SCHEMA \`${schema}\` CASCADE;`))
+            await db[execute](sql.raw(`CREATE SCHEMA \`${schema}\`;`))
             consola.debug(`Cleared schema \`${schema}\``)
           } catch (error) {
             consola.error(`Failed to clear schema \`${schema}\`: ${error.message}`)
@@ -153,7 +153,7 @@ export default defineCommand({
       for (const table of tables) {
         try {
           consola.debug(`Dropping table \`${table}\`...`)
-          await db[execute](sql.raw(`DROP TABLE IF EXISTS "${table}";`))
+          await db[execute](sql.raw(`DROP TABLE IF EXISTS \`${table}\`;`))
           consola.success(`Dropped table \`${table}\``)
         } catch (error) {
           consola.error(`Failed to drop table \`${table}\`: ${error.message}`)

--- a/cli/commands/db/drop-all.mjs
+++ b/cli/commands/db/drop-all.mjs
@@ -6,6 +6,7 @@ import { join } from 'pathe'
 import { createDrizzleClient } from '@nuxthub/core/db'
 import { sql } from 'drizzle-orm'
 import { loadDotenv, dotenvArg } from '../../utils/dotenv.mjs'
+import { quoteIdentifier } from '../../utils/db.mjs'
 
 /**
  * Get the query to list all tables based on the database dialect
@@ -110,8 +111,8 @@ export default defineCommand({
         for (const schema of schemas) {
           try {
             consola.debug(`Dropping schema \`${schema}\`...`)
-            await db[execute](sql.raw(`DROP SCHEMA \`${schema}\` CASCADE;`))
-            await db[execute](sql.raw(`CREATE SCHEMA \`${schema}\`;`))
+            await db[execute](sql.raw(`DROP SCHEMA ${quoteIdentifier(schema, dialect)} CASCADE;`))
+            await db[execute](sql.raw(`CREATE SCHEMA ${quoteIdentifier(schema, dialect)};`))
             consola.debug(`Cleared schema \`${schema}\``)
           } catch (error) {
             consola.error(`Failed to clear schema \`${schema}\`: ${error.message}`)
@@ -153,7 +154,7 @@ export default defineCommand({
       for (const table of tables) {
         try {
           consola.debug(`Dropping table \`${table}\`...`)
-          await db[execute](sql.raw(`DROP TABLE IF EXISTS \`${table}\`;`))
+          await db[execute](sql.raw(`DROP TABLE IF EXISTS ${quoteIdentifier(table, dialect)};`))
           consola.success(`Dropped table \`${table}\``)
         } catch (error) {
           consola.error(`Failed to drop table \`${table}\`: ${error.message}`)

--- a/cli/commands/db/drop.mjs
+++ b/cli/commands/db/drop.mjs
@@ -51,7 +51,7 @@ export default defineCommand({
     const hubDir = join(cwd, hubConfig.dir)
     const db = await createDrizzleClient(hubConfig.db, hubDir)
     const execute = hubConfig.db.dialect === 'sqlite' ? 'run' : 'execute'
-    await db[execute](sql.raw(`DROP TABLE IF EXISTS "${args.table}";`))
+    await db[execute](sql.raw(`DROP TABLE IF EXISTS \`${args.table}\`;`))
     consola.success(`Table \`${args.table}\` dropped successfully.`)
     await db.$client?.end?.()
   }

--- a/cli/commands/db/drop.mjs
+++ b/cli/commands/db/drop.mjs
@@ -6,6 +6,7 @@ import { join } from 'pathe'
 import { createDrizzleClient } from '@nuxthub/core/db'
 import { sql } from 'drizzle-orm'
 import { loadDotenv, dotenvArg } from '../../utils/dotenv.mjs'
+import { quoteIdentifier } from '../../utils/db.mjs'
 
 export default defineCommand({
   meta: {
@@ -51,7 +52,8 @@ export default defineCommand({
     const hubDir = join(cwd, hubConfig.dir)
     const db = await createDrizzleClient(hubConfig.db, hubDir)
     const execute = hubConfig.db.dialect === 'sqlite' ? 'run' : 'execute'
-    await db[execute](sql.raw(`DROP TABLE IF EXISTS \`${args.table}\`;`))
+    const dialect = hubConfig.db.dialect
+    await db[execute](sql.raw(`DROP TABLE IF EXISTS ${quoteIdentifier(args.table, dialect)};`))
     consola.success(`Table \`${args.table}\` dropped successfully.`)
     await db.$client?.end?.()
   }

--- a/cli/commands/db/mark-as-migrated.mjs
+++ b/cli/commands/db/mark-as-migrated.mjs
@@ -75,7 +75,7 @@ export default defineCommand({
     }
     // If a specific migration is provided, mark it as applied
     if (args.name) {
-      await db[execute](sql.raw(`INSERT INTO "_hub_migrations" (name) values ('${args.name}');`))
+      await db[execute](sql.raw(`INSERT INTO \`_hub_migrations\` (name) VALUES ('${args.name}');`))
       consola.success(`Local migration \`${args.name}\` marked as applied.`)
       return closeDb()
     }
@@ -97,7 +97,7 @@ export default defineCommand({
         consola.info(`Migration \`${migration.name}\` skipped.`)
         continue
       }
-      await db[execute](sql.raw(`INSERT INTO "_hub_migrations" (name) values ('${migration.name}');`))
+      await db[execute](sql.raw(`INSERT INTO \`_hub_migrations\` (name) VALUES ('${migration.name}');`))
       consola.success(`Migration \`${migration.name}\` marked as applied.`)
       migrationsMarkedAsApplied++
     }

--- a/cli/commands/db/mark-as-migrated.mjs
+++ b/cli/commands/db/mark-as-migrated.mjs
@@ -6,6 +6,7 @@ import { join } from 'pathe'
 import { createDrizzleClient, getDatabaseMigrationFiles, AppliedDatabaseMigrationsQuery } from '@nuxthub/core/db'
 import { sql } from 'drizzle-orm'
 import { loadDotenv, dotenvArg } from '../../utils/dotenv.mjs'
+import { quoteIdentifier } from '../../utils/db.mjs'
 
 export default defineCommand({
   meta: {
@@ -75,7 +76,8 @@ export default defineCommand({
     }
     // If a specific migration is provided, mark it as applied
     if (args.name) {
-      await db[execute](sql.raw(`INSERT INTO \`_hub_migrations\` (name) VALUES ('${args.name}');`))
+      const migrationsTable = quoteIdentifier('_hub_migrations', dialect)
+      await db[execute](sql.raw(`INSERT INTO ${migrationsTable} (name) VALUES ('${args.name}');`))
       consola.success(`Local migration \`${args.name}\` marked as applied.`)
       return closeDb()
     }
@@ -86,6 +88,7 @@ export default defineCommand({
       return closeDb()
     }
     consola.info(`Found \`${pendingMigrations.length}\` pending migration${pendingMigrations.length === 1 ? '' : 's'}`)
+    const migrationsTable = quoteIdentifier('_hub_migrations', dialect)
     let migrationsMarkedAsApplied = 0
     for (const migration of pendingMigrations) {
       const confirmed = await consola.prompt(`Mark migration \`${migration.name}\` as applied?`, {
@@ -97,7 +100,7 @@ export default defineCommand({
         consola.info(`Migration \`${migration.name}\` skipped.`)
         continue
       }
-      await db[execute](sql.raw(`INSERT INTO \`_hub_migrations\` (name) VALUES ('${migration.name}');`))
+      await db[execute](sql.raw(`INSERT INTO ${migrationsTable} (name) VALUES ('${migration.name}');`))
       consola.success(`Migration \`${migration.name}\` marked as applied.`)
       migrationsMarkedAsApplied++
     }

--- a/cli/commands/db/squash.mjs
+++ b/cli/commands/db/squash.mjs
@@ -204,7 +204,7 @@ export default defineCommand({
         const db = await createDrizzleClient(hubConfig.db, hubDir)
         const dialect = hubConfig.db.dialect
         const execute = dialect === 'sqlite' ? 'run' : 'execute'
-        await db[execute](sql.raw(`INSERT INTO "_hub_migrations" (name) values ('${newMigration.tag}');`))
+        await db[execute](sql.raw(`INSERT INTO \`_hub_migrations\` (name) VALUES ('${newMigration.tag}');`))
         await db.$client?.end?.()
         consola.success(`Migration \`${newMigration.tag}\` marked as applied.`)
       } else {

--- a/cli/commands/db/squash.mjs
+++ b/cli/commands/db/squash.mjs
@@ -5,7 +5,7 @@ import { readFile, writeFile, rm } from 'node:fs/promises'
 import { join, resolve } from 'pathe'
 import { buildDatabaseSchema, createDrizzleClient } from '@nuxthub/core/db'
 import { sql } from 'drizzle-orm'
-import { getTsconfigAliases } from '../../utils/db.mjs'
+import { getTsconfigAliases, quoteIdentifier } from '../../utils/db.mjs'
 
 export default defineCommand({
   meta: {
@@ -204,7 +204,7 @@ export default defineCommand({
         const db = await createDrizzleClient(hubConfig.db, hubDir)
         const dialect = hubConfig.db.dialect
         const execute = dialect === 'sqlite' ? 'run' : 'execute'
-        await db[execute](sql.raw(`INSERT INTO \`_hub_migrations\` (name) VALUES ('${newMigration.tag}');`))
+        await db[execute](sql.raw(`INSERT INTO ${quoteIdentifier('_hub_migrations', dialect)} (name) VALUES ('${newMigration.tag}');`))
         await db.$client?.end?.()
         consola.success(`Migration \`${newMigration.tag}\` marked as applied.`)
       } else {

--- a/cli/utils/db.mjs
+++ b/cli/utils/db.mjs
@@ -34,6 +34,17 @@ export async function getNextMigrationNumber() {
   return (lastSequentialMigrationNumber + 1).toString().padStart(4, '0')
 }
 
+/**
+ * Quote a SQL identifier using the correct syntax for the given dialect.
+ * PostgreSQL uses double quotes, MySQL and SQLite use backticks.
+ */
+export function quoteIdentifier(name, dialect) {
+  if (dialect === 'postgresql') {
+    return `"${name}"`
+  }
+  return `\`${name}\``
+}
+
 export async function getTsconfigAliases(cwd) {
   try {
     const tsconfig = JSON.parse(await readFile(join(cwd, '.nuxt/tsconfig.json'), 'utf-8'))


### PR DESCRIPTION
- Add `quoteIdentifier(name, dialect)` helper to `cli/utils/db.mjs` that returns double-quoted identifiers for PostgreSQL and backtick-quoted identifiers for MySQL/SQLite
- Replace all hardcoded identifier quoting in CLI database commands with the new helper

The CLI commands (`drop`, `drop-all`, `mark-as-migrated`, `squash`) used double-quoted identifiers (`"table_name"`), which is not recognized by MySQL without `ANSI_QUOTES` mode enabled.