### PR TITLE
fix(db): avoid reusing hyperdrive postgres client

### DIFF
--- a/src/db/runtime/plugins/request-context.ts
+++ b/src/db/runtime/plugins/request-context.ts
@@ -1,0 +1,15 @@
+import { defineNitroPlugin, useEvent } from '#imports'
+
+declare global {
+  var __nuxthubUseNitroEvent: (() => unknown) | undefined
+}
+
+export default defineNitroPlugin(() => {
+  globalThis.__nuxthubUseNitroEvent = () => {
+    try {
+      return useEvent()
+    } catch {
+      return undefined
+    }
+  }
+})

--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -531,13 +531,32 @@ export { db, schema }
     drizzleOrmContent = driver === 'postgres-js'
       ? `import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
+import { useEvent } from 'nitropack/runtime/context'
 import * as schema from './db/schema.mjs'
 
-function getDb() {
+function resolveHyperdrive() {
   const hyperdrive = process.env.${bindingName} || globalThis.__env__?.${bindingName} || globalThis.${bindingName}
   if (!hyperdrive) throw new Error('${bindingName} binding not found')
+  return hyperdrive
+}
+
+function createDb(hyperdrive) {
   const client = postgres(hyperdrive.connectionString, ${hyperdrivePostgresOpts})
   return drizzle({ client, schema${casingOption} })
+}
+
+function getDb() {
+  const hyperdrive = resolveHyperdrive()
+
+  try {
+    const event = useEvent()
+    if (event?.context) {
+      event.context.__nuxthubHyperdrivePostgresDb ??= createDb(hyperdrive)
+      return event.context.__nuxthubHyperdrivePostgresDb
+    }
+  } catch {}
+
+  return createDb(hyperdrive)
 }
 
 const db = new Proxy({}, {

--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -159,6 +159,9 @@ export async function setupDatabase(nuxt: Nuxt, hub: HubConfig, deps: Record<str
     const binding = driver === 'postgres-js' ? 'POSTGRES' : 'MYSQL'
     addWranglerBinding(nuxt, 'hyperdrive', { binding, id: connection.hyperdriveId })
   }
+  if (driver === 'postgres-js' && hub.hosting.includes('cloudflare') && connection?.hyperdriveId) {
+    addServerPlugin(resolve('db/runtime/plugins/request-context'))
+  }
 
   // Verify development database dependencies are installed
   if (!deps['drizzle-orm'] || !deps['drizzle-kit']) {
@@ -343,6 +346,14 @@ async function setupDatabaseClient(nuxt: Nuxt, hub: ResolvedHubConfig) {
     const { url: _, ...rest } = connection as Record<string, unknown>
     return Object.keys(rest).length ? `{ onnotice: () => {}, ...${JSON.stringify(rest)} }` : '{ onnotice: () => {} }'
   })()
+  const hyperdrivePostgresOpts = (() => {
+    if (driver !== 'postgres-js' || !connection) return '{ onnotice: () => {}, prepare: false }'
+    const { url: _, hyperdriveId: __, ...rest } = connection as Record<string, unknown>
+    const hasPrepare = Object.prototype.hasOwnProperty.call(rest, 'prepare')
+    return Object.keys(rest).length
+      ? `{ onnotice: () => {}, ...${JSON.stringify(rest)}${hasPrepare ? '' : ', prepare: false'} }`
+      : '{ onnotice: () => {}, prepare: false }'
+  })()
 
   // For types, d1-http uses sqlite-proxy
   const driverForTypes = driver === 'd1-http' ? 'sqlite-proxy' : driver
@@ -520,12 +531,56 @@ export { db, schema }
   }
   if (['postgres-js', 'mysql2'].includes(driver) && hub.hosting.includes('cloudflare') && connection?.hyperdriveId) {
     const bindingName = driver === 'postgres-js' ? 'POSTGRES' : 'MYSQL'
-    drizzleOrmContent = generateLazyDbTemplate(
-      `import { drizzle } from 'drizzle-orm/${driver}'`,
-      `    const hyperdrive = process.env.${bindingName} || globalThis.__env__?.${bindingName} || globalThis.${bindingName}
+    drizzleOrmContent = driver === 'postgres-js'
+      ? `import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+import * as schema from './db/schema.mjs'
+
+function resolveHyperdrive() {
+  const hyperdrive = process.env.${bindingName} || globalThis.__env__?.${bindingName} || globalThis.${bindingName}
+  if (!hyperdrive) throw new Error('${bindingName} binding not found')
+  return hyperdrive
+}
+
+function createDb(hyperdrive) {
+  const client = postgres(hyperdrive.connectionString, ${hyperdrivePostgresOpts})
+  return drizzle({ client, schema${casingOption} })
+}
+
+function getRequestContext() {
+  try {
+    return globalThis.__nuxthubUseNitroEvent?.()?.context
+  } catch {}
+}
+
+function getDb() {
+  const hyperdrive = resolveHyperdrive()
+  const context = getRequestContext()
+
+  if (context) {
+    context.__nuxthubHyperdrivePostgresDb ??= createDb(hyperdrive)
+    return context.__nuxthubHyperdrivePostgresDb
+  }
+
+  return createDb(hyperdrive)
+}
+
+const db = new Proxy({}, {
+  get(_, prop) {
+    const target = getDb()
+    const value = target[prop]
+    return typeof value === 'function' ? value.bind(target) : value
+  }
+})
+
+export { db, schema }
+`
+      : generateLazyDbTemplate(
+          `import { drizzle } from 'drizzle-orm/${driver}'`,
+          `    const hyperdrive = process.env.${bindingName} || globalThis.__env__?.${bindingName} || globalThis.${bindingName}
     if (!hyperdrive) throw new Error('${bindingName} binding not found')
     _db = drizzle({ connection: hyperdrive.connectionString, schema${modeOption}${casingOption} })`
-    )
+        )
   }
   // Non-CF postgres-js: lazy env resolution for Docker/multi-deploy scenarios
   if (driver === 'postgres-js' && !nuxt.options.dev && !hub.hosting.includes('cloudflare')) {

--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -343,6 +343,14 @@ async function setupDatabaseClient(nuxt: Nuxt, hub: ResolvedHubConfig) {
     const { url: _, ...rest } = connection as Record<string, unknown>
     return Object.keys(rest).length ? `{ onnotice: () => {}, ...${JSON.stringify(rest)} }` : '{ onnotice: () => {} }'
   })()
+  const hyperdrivePostgresOpts = (() => {
+    if (driver !== 'postgres-js' || !connection) return '{ onnotice: () => {}, prepare: false }'
+    const { url: _, hyperdriveId: __, ...rest } = connection as Record<string, unknown>
+    const hasPrepare = Object.prototype.hasOwnProperty.call(rest, 'prepare')
+    return Object.keys(rest).length
+      ? `{ onnotice: () => {}, ...${JSON.stringify(rest)}${hasPrepare ? '' : ', prepare: false'} }`
+      : '{ onnotice: () => {}, prepare: false }'
+  })()
 
   // For types, d1-http uses sqlite-proxy
   const driverForTypes = driver === 'd1-http' ? 'sqlite-proxy' : driver
@@ -520,12 +528,34 @@ export { db, schema }
   }
   if (['postgres-js', 'mysql2'].includes(driver) && hub.hosting.includes('cloudflare') && connection?.hyperdriveId) {
     const bindingName = driver === 'postgres-js' ? 'POSTGRES' : 'MYSQL'
-    drizzleOrmContent = generateLazyDbTemplate(
-      `import { drizzle } from 'drizzle-orm/${driver}'`,
-      `    const hyperdrive = process.env.${bindingName} || globalThis.__env__?.${bindingName} || globalThis.${bindingName}
+    drizzleOrmContent = driver === 'postgres-js'
+      ? `import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+import * as schema from './db/schema.mjs'
+
+function getDb() {
+  const hyperdrive = process.env.${bindingName} || globalThis.__env__?.${bindingName} || globalThis.${bindingName}
+  if (!hyperdrive) throw new Error('${bindingName} binding not found')
+  const client = postgres(hyperdrive.connectionString, ${hyperdrivePostgresOpts})
+  return drizzle({ client, schema${casingOption} })
+}
+
+const db = new Proxy({}, {
+  get(_, prop) {
+    const target = getDb()
+    const value = target[prop]
+    return typeof value === 'function' ? value.bind(target) : value
+  }
+})
+
+export { db, schema }
+`
+      : generateLazyDbTemplate(
+          `import { drizzle } from 'drizzle-orm/${driver}'`,
+          `    const hyperdrive = process.env.${bindingName} || globalThis.__env__?.${bindingName} || globalThis.${bindingName}
     if (!hyperdrive) throw new Error('${bindingName} binding not found')
     _db = drizzle({ connection: hyperdrive.connectionString, schema${modeOption}${casingOption} })`
-    )
+        )
   }
   // Non-CF postgres-js: lazy env resolution for Docker/multi-deploy scenarios
   if (driver === 'postgres-js' && !nuxt.options.dev && !hub.hosting.includes('cloudflare')) {

--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -159,6 +159,9 @@ export async function setupDatabase(nuxt: Nuxt, hub: HubConfig, deps: Record<str
     const binding = driver === 'postgres-js' ? 'POSTGRES' : 'MYSQL'
     addWranglerBinding(nuxt, 'hyperdrive', { binding, id: connection.hyperdriveId })
   }
+  if (driver === 'postgres-js' && hub.hosting.includes('cloudflare') && connection?.hyperdriveId) {
+    addServerPlugin(resolve('db/runtime/plugins/request-context'))
+  }
 
   // Verify development database dependencies are installed
   if (!deps['drizzle-orm'] || !deps['drizzle-kit']) {
@@ -531,7 +534,6 @@ export { db, schema }
     drizzleOrmContent = driver === 'postgres-js'
       ? `import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
-import { useEvent } from 'nitropack/runtime/context'
 import * as schema from './db/schema.mjs'
 
 function resolveHyperdrive() {
@@ -545,16 +547,20 @@ function createDb(hyperdrive) {
   return drizzle({ client, schema${casingOption} })
 }
 
+function getRequestContext() {
+  try {
+    return globalThis.__nuxthubUseNitroEvent?.()?.context
+  } catch {}
+}
+
 function getDb() {
   const hyperdrive = resolveHyperdrive()
+  const context = getRequestContext()
 
-  try {
-    const event = useEvent()
-    if (event?.context) {
-      event.context.__nuxthubHyperdrivePostgresDb ??= createDb(hyperdrive)
-      return event.context.__nuxthubHyperdrivePostgresDb
-    }
-  } catch {}
+  if (context) {
+    context.__nuxthubHyperdrivePostgresDb ??= createDb(hyperdrive)
+    return context.__nuxthubHyperdrivePostgresDb
+  }
 
   return createDb(hyperdrive)
 }

--- a/test/database.hyperdrive.test.ts
+++ b/test/database.hyperdrive.test.ts
@@ -1,9 +1,41 @@
-import { readFile } from 'node:fs/promises'
-import { fileURLToPath } from 'node:url'
-import { describe, expect, it } from 'vitest'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { setup } from '@nuxt/test-utils'
 
 const fixtureRoot = fileURLToPath(new URL('./fixtures/hyperdrive-postgres', import.meta.url))
+const dbClientPath = fileURLToPath(new URL('./fixtures/hyperdrive-postgres/node_modules/@nuxthub/db/db.mjs', import.meta.url))
+
+async function importDbClientModule(stubs: {
+  postgres: (...args: unknown[]) => unknown
+  drizzle: (...args: unknown[]) => unknown
+  useEvent: () => unknown
+}) {
+  const dbClient = await readFile(dbClientPath, 'utf8')
+  const tempDir = await mkdtemp(join(tmpdir(), 'nuxthub-hyperdrive-postgres-'))
+  const tempModulePath = join(tempDir, 'db.mjs')
+
+  const rewrittenDbClient = dbClient
+    .replace(`from 'drizzle-orm/postgres-js'`, `from './drizzle-stub.mjs'`)
+    .replace(`from 'postgres'`, `from './postgres-stub.mjs'`)
+    .replace(`from 'nitropack/runtime/context'`, `from './context-stub.mjs'`)
+
+  // @ts-expect-error - test-only global stub registry
+  globalThis.__nuxthubHyperdriveTestStubs = stubs
+
+  await writeFile(tempModulePath, rewrittenDbClient)
+  await writeFile(join(tempDir, 'postgres-stub.mjs'), `export default (...args) => globalThis.__nuxthubHyperdriveTestStubs.postgres(...args)\n`)
+  await writeFile(join(tempDir, 'drizzle-stub.mjs'), `export const drizzle = (...args) => globalThis.__nuxthubHyperdriveTestStubs.drizzle(...args)\n`)
+  await writeFile(join(tempDir, 'context-stub.mjs'), `export const useEvent = () => globalThis.__nuxthubHyperdriveTestStubs.useEvent()\n`)
+  await writeFile(join(tempDir, 'schema.mjs'), `export const schemaMarker = true\n`)
+
+  return {
+    module: await import(`${pathToFileURL(tempModulePath).href}?t=${Date.now()}-${Math.random()}`),
+    cleanup: () => rm(tempDir, { recursive: true, force: true })
+  }
+}
 
 describe('hyperdrive postgres runtime client', async () => {
   await setup({
@@ -11,14 +43,112 @@ describe('hyperdrive postgres runtime client', async () => {
     dev: true
   })
 
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.POSTGRES
+    // @ts-expect-error - test-only global cleanup
+    delete globalThis.__env__
+    // @ts-expect-error - test-only global cleanup
+    delete globalThis.POSTGRES
+    // @ts-expect-error - test-only global cleanup
+    delete globalThis.__nuxthubHyperdriveTestStubs
+  })
+
   it('generates a fresh postgres client for the cloudflare hyperdrive path', async () => {
-    const dbClientPath = fileURLToPath(new URL('./fixtures/hyperdrive-postgres/node_modules/@nuxthub/db/db.mjs', import.meta.url))
     const dbClient = await readFile(dbClientPath, 'utf8')
 
     expect(dbClient).toContain(`import postgres from 'postgres'`)
+    expect(dbClient).toContain(`import { useEvent } from 'nitropack/runtime/context'`)
+    expect(dbClient).toContain('event.context.__nuxthubHyperdrivePostgresDb ??= createDb(hyperdrive)')
     expect(dbClient).toContain('function getDb() {')
+    expect(dbClient).toContain('function createDb(hyperdrive) {')
     expect(dbClient).toContain('const client = postgres(hyperdrive.connectionString')
     expect(dbClient).toContain('return drizzle({ client, schema')
     expect(dbClient).not.toContain('let _db')
+  })
+
+  it('reuses one postgres client within the same request context', async () => {
+    // @ts-expect-error - test-only global binding
+    globalThis.__env__ = { POSTGRES: { connectionString: 'postgres://hyperdrive/same-request' } }
+
+    const postgresMock = vi.fn((connectionString: string) => ({ connectionString }))
+    const drizzleMock = vi.fn(({ client }: { client: { connectionString: string } }) => ({
+      select: () => client.connectionString,
+      insert: () => client.connectionString
+    }))
+    const event = { context: {} as Record<string, unknown> }
+
+    const { module, cleanup } = await importDbClientModule({
+      postgres: postgresMock,
+      drizzle: drizzleMock,
+      useEvent: () => event
+    })
+
+    try {
+      void module.db.select
+      void module.db.insert
+
+      expect(postgresMock).toHaveBeenCalledTimes(1)
+      expect(drizzleMock).toHaveBeenCalledTimes(1)
+      expect(event.context.__nuxthubHyperdrivePostgresDb).toBeDefined()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('creates a new postgres client for different request contexts', async () => {
+    // @ts-expect-error - test-only global binding
+    globalThis.__env__ = { POSTGRES: { connectionString: 'postgres://hyperdrive/different-requests' } }
+
+    const postgresMock = vi.fn((connectionString: string) => ({ connectionString }))
+    const drizzleMock = vi.fn(({ client }: { client: { connectionString: string } }) => ({
+      select: () => client.connectionString
+    }))
+    let event = { context: {} as Record<string, unknown> }
+
+    const { module, cleanup } = await importDbClientModule({
+      postgres: postgresMock,
+      drizzle: drizzleMock,
+      useEvent: () => event
+    })
+
+    try {
+      void module.db.select
+      event = { context: {} as Record<string, unknown> }
+      void module.db.select
+
+      expect(postgresMock).toHaveBeenCalledTimes(2)
+      expect(drizzleMock).toHaveBeenCalledTimes(2)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('falls back to non-cached clients when request context is unavailable', async () => {
+    // @ts-expect-error - test-only global binding
+    globalThis.__env__ = { POSTGRES: { connectionString: 'postgres://hyperdrive/no-context' } }
+
+    const postgresMock = vi.fn((connectionString: string) => ({ connectionString }))
+    const drizzleMock = vi.fn(({ client }: { client: { connectionString: string } }) => ({
+      select: () => client.connectionString
+    }))
+
+    const { module, cleanup } = await importDbClientModule({
+      postgres: postgresMock,
+      drizzle: drizzleMock,
+      useEvent: () => {
+        throw new Error('no request context')
+      }
+    })
+
+    try {
+      void module.db.select
+      void module.db.select
+
+      expect(postgresMock).toHaveBeenCalledTimes(2)
+      expect(drizzleMock).toHaveBeenCalledTimes(2)
+    } finally {
+      await cleanup()
+    }
   })
 })

--- a/test/database.hyperdrive.test.ts
+++ b/test/database.hyperdrive.test.ts
@@ -1,0 +1,24 @@
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { setup } from '@nuxt/test-utils'
+
+const fixtureRoot = fileURLToPath(new URL('./fixtures/hyperdrive-postgres', import.meta.url))
+
+describe('hyperdrive postgres runtime client', async () => {
+  await setup({
+    rootDir: fixtureRoot,
+    dev: true
+  })
+
+  it('generates a fresh postgres client for the cloudflare hyperdrive path', async () => {
+    const dbClientPath = fileURLToPath(new URL('./fixtures/hyperdrive-postgres/node_modules/@nuxthub/db/db.mjs', import.meta.url))
+    const dbClient = await readFile(dbClientPath, 'utf8')
+
+    expect(dbClient).toContain(`import postgres from 'postgres'`)
+    expect(dbClient).toContain('function getDb() {')
+    expect(dbClient).toContain('const client = postgres(hyperdrive.connectionString')
+    expect(dbClient).toContain('return drizzle({ client, schema')
+    expect(dbClient).not.toContain('let _db')
+  })
+})

--- a/test/database.hyperdrive.test.ts
+++ b/test/database.hyperdrive.test.ts
@@ -1,7 +1,8 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
+import { createJiti } from 'jiti'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { setup } from '@nuxt/test-utils'
 
@@ -11,7 +12,7 @@ const dbClientPath = fileURLToPath(new URL('./fixtures/hyperdrive-postgres/node_
 async function importDbClientModule(stubs: {
   postgres: (...args: unknown[]) => unknown
   drizzle: (...args: unknown[]) => unknown
-  useEvent: () => unknown
+  getEvent?: () => unknown
 }) {
   const dbClient = await readFile(dbClientPath, 'utf8')
   const tempDir = await mkdtemp(join(tmpdir(), 'nuxthub-hyperdrive-postgres-'))
@@ -20,15 +21,15 @@ async function importDbClientModule(stubs: {
   const rewrittenDbClient = dbClient
     .replace(`from 'drizzle-orm/postgres-js'`, `from './drizzle-stub.mjs'`)
     .replace(`from 'postgres'`, `from './postgres-stub.mjs'`)
-    .replace(`from 'nitropack/runtime/context'`, `from './context-stub.mjs'`)
 
   // @ts-expect-error - test-only global stub registry
   globalThis.__nuxthubHyperdriveTestStubs = stubs
+  // @ts-expect-error - test-only global runtime bridge
+  globalThis.__nuxthubUseNitroEvent = stubs.getEvent
 
   await writeFile(tempModulePath, rewrittenDbClient)
   await writeFile(join(tempDir, 'postgres-stub.mjs'), `export default (...args) => globalThis.__nuxthubHyperdriveTestStubs.postgres(...args)\n`)
   await writeFile(join(tempDir, 'drizzle-stub.mjs'), `export const drizzle = (...args) => globalThis.__nuxthubHyperdriveTestStubs.drizzle(...args)\n`)
-  await writeFile(join(tempDir, 'context-stub.mjs'), `export const useEvent = () => globalThis.__nuxthubHyperdriveTestStubs.useEvent()\n`)
   await writeFile(join(tempDir, 'schema.mjs'), `export const schemaMarker = true\n`)
 
   return {
@@ -52,15 +53,20 @@ describe('hyperdrive postgres runtime client', async () => {
     delete globalThis.POSTGRES
     // @ts-expect-error - test-only global cleanup
     delete globalThis.__nuxthubHyperdriveTestStubs
+    // @ts-expect-error - test-only global cleanup
+    delete globalThis.__nuxthubUseNitroEvent
   })
 
   it('generates a fresh postgres client for the cloudflare hyperdrive path', async () => {
     const dbClient = await readFile(dbClientPath, 'utf8')
 
     expect(dbClient).toContain(`import postgres from 'postgres'`)
-    expect(dbClient).toContain(`import { useEvent } from 'nitropack/runtime/context'`)
-    expect(dbClient).toContain('event.context.__nuxthubHyperdrivePostgresDb ??= createDb(hyperdrive)')
+    expect(dbClient).not.toContain('nitropack/runtime/context')
+    expect(dbClient).not.toContain('useEvent')
+    expect(dbClient).toContain('globalThis.__nuxthubUseNitroEvent')
+    expect(dbClient).toContain('context.__nuxthubHyperdrivePostgresDb ??= createDb(hyperdrive)')
     expect(dbClient).toContain('function getDb() {')
+    expect(dbClient).toContain('function getRequestContext() {')
     expect(dbClient).toContain('function createDb(hyperdrive) {')
     expect(dbClient).toContain('const client = postgres(hyperdrive.connectionString')
     expect(dbClient).toContain('return drizzle({ client, schema')
@@ -81,7 +87,7 @@ describe('hyperdrive postgres runtime client', async () => {
     const { module, cleanup } = await importDbClientModule({
       postgres: postgresMock,
       drizzle: drizzleMock,
-      useEvent: () => event
+      getEvent: () => event
     })
 
     try {
@@ -109,7 +115,7 @@ describe('hyperdrive postgres runtime client', async () => {
     const { module, cleanup } = await importDbClientModule({
       postgres: postgresMock,
       drizzle: drizzleMock,
-      useEvent: () => event
+      getEvent: () => event
     })
 
     try {
@@ -135,10 +141,7 @@ describe('hyperdrive postgres runtime client', async () => {
 
     const { module, cleanup } = await importDbClientModule({
       postgres: postgresMock,
-      drizzle: drizzleMock,
-      useEvent: () => {
-        throw new Error('no request context')
-      }
+      drizzle: drizzleMock
     })
 
     try {
@@ -149,6 +152,39 @@ describe('hyperdrive postgres runtime client', async () => {
       expect(drizzleMock).toHaveBeenCalledTimes(2)
     } finally {
       await cleanup()
+    }
+  })
+
+  it('can be loaded by Jiti without resolving Nitro runtime context', async () => {
+    const dbClient = await readFile(dbClientPath, 'utf8')
+    const tempDir = await mkdtemp(join(tmpdir(), 'nuxthub-hyperdrive-postgres-jiti-'))
+    const tempModulePath = join(tempDir, 'db.mjs')
+    const nitropackDir = join(tempDir, 'node_modules/nitropack')
+
+    const rewrittenDbClient = dbClient
+      .replace(`from 'drizzle-orm/postgres-js'`, `from './drizzle-stub.mjs'`)
+      .replace(`from 'postgres'`, `from './postgres-stub.mjs'`)
+
+    try {
+      await mkdir(nitropackDir, { recursive: true })
+      await writeFile(tempModulePath, rewrittenDbClient)
+      await writeFile(join(tempDir, 'postgres-stub.mjs'), `export default () => ({})\n`)
+      await writeFile(join(tempDir, 'drizzle-stub.mjs'), `export const drizzle = () => ({})\n`)
+      await writeFile(join(tempDir, 'schema.mjs'), `export const schemaMarker = true\n`)
+      await writeFile(join(nitropackDir, 'package.json'), JSON.stringify({
+        name: 'nitropack',
+        version: '0.0.0',
+        type: 'module',
+        exports: {
+          '.': './index.mjs'
+        }
+      }, null, 2))
+
+      const jiti = createJiti(tempModulePath, { moduleCache: false })
+
+      await expect(jiti.import(tempModulePath)).resolves.toHaveProperty('schema')
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
     }
   })
 })

--- a/test/database.hyperdrive.test.ts
+++ b/test/database.hyperdrive.test.ts
@@ -1,0 +1,190 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { createJiti } from 'jiti'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { setup } from '@nuxt/test-utils'
+
+const fixtureRoot = fileURLToPath(new URL('./fixtures/hyperdrive-postgres', import.meta.url))
+const dbClientPath = fileURLToPath(new URL('./fixtures/hyperdrive-postgres/node_modules/@nuxthub/db/db.mjs', import.meta.url))
+
+async function importDbClientModule(stubs: {
+  postgres: (...args: unknown[]) => unknown
+  drizzle: (...args: unknown[]) => unknown
+  getEvent?: () => unknown
+}) {
+  const dbClient = await readFile(dbClientPath, 'utf8')
+  const tempDir = await mkdtemp(join(tmpdir(), 'nuxthub-hyperdrive-postgres-'))
+  const tempModulePath = join(tempDir, 'db.mjs')
+
+  const rewrittenDbClient = dbClient
+    .replace(`from 'drizzle-orm/postgres-js'`, `from './drizzle-stub.mjs'`)
+    .replace(`from 'postgres'`, `from './postgres-stub.mjs'`)
+
+  // @ts-expect-error - test-only global stub registry
+  globalThis.__nuxthubHyperdriveTestStubs = stubs
+  // @ts-expect-error - test-only global runtime bridge
+  globalThis.__nuxthubUseNitroEvent = stubs.getEvent
+
+  await writeFile(tempModulePath, rewrittenDbClient)
+  await writeFile(join(tempDir, 'postgres-stub.mjs'), `export default (...args) => globalThis.__nuxthubHyperdriveTestStubs.postgres(...args)\n`)
+  await writeFile(join(tempDir, 'drizzle-stub.mjs'), `export const drizzle = (...args) => globalThis.__nuxthubHyperdriveTestStubs.drizzle(...args)\n`)
+  await writeFile(join(tempDir, 'schema.mjs'), `export const schemaMarker = true\n`)
+
+  return {
+    module: await import(`${pathToFileURL(tempModulePath).href}?t=${Date.now()}-${Math.random()}`),
+    cleanup: () => rm(tempDir, { recursive: true, force: true })
+  }
+}
+
+describe('hyperdrive postgres runtime client', async () => {
+  await setup({
+    rootDir: fixtureRoot,
+    dev: true
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete process.env.POSTGRES
+    // @ts-expect-error - test-only global cleanup
+    delete globalThis.__env__
+    // @ts-expect-error - test-only global cleanup
+    delete globalThis.POSTGRES
+    // @ts-expect-error - test-only global cleanup
+    delete globalThis.__nuxthubHyperdriveTestStubs
+    // @ts-expect-error - test-only global cleanup
+    delete globalThis.__nuxthubUseNitroEvent
+  })
+
+  it('generates a fresh postgres client for the cloudflare hyperdrive path', async () => {
+    const dbClient = await readFile(dbClientPath, 'utf8')
+
+    expect(dbClient).toContain(`import postgres from 'postgres'`)
+    expect(dbClient).not.toContain('nitropack/runtime/context')
+    expect(dbClient).not.toContain('useEvent')
+    expect(dbClient).toContain('globalThis.__nuxthubUseNitroEvent')
+    expect(dbClient).toContain('context.__nuxthubHyperdrivePostgresDb ??= createDb(hyperdrive)')
+    expect(dbClient).toContain('function getDb() {')
+    expect(dbClient).toContain('function getRequestContext() {')
+    expect(dbClient).toContain('function createDb(hyperdrive) {')
+    expect(dbClient).toContain('const client = postgres(hyperdrive.connectionString')
+    expect(dbClient).toContain('return drizzle({ client, schema')
+    expect(dbClient).not.toContain('let _db')
+  })
+
+  it('reuses one postgres client within the same request context', async () => {
+    // @ts-expect-error - test-only global binding
+    globalThis.__env__ = { POSTGRES: { connectionString: 'postgres://hyperdrive/same-request' } }
+
+    const postgresMock = vi.fn((connectionString: string) => ({ connectionString }))
+    const drizzleMock = vi.fn(({ client }: { client: { connectionString: string } }) => ({
+      select: () => client.connectionString,
+      insert: () => client.connectionString
+    }))
+    const event = { context: {} as Record<string, unknown> }
+
+    const { module, cleanup } = await importDbClientModule({
+      postgres: postgresMock,
+      drizzle: drizzleMock,
+      getEvent: () => event
+    })
+
+    try {
+      void module.db.select
+      void module.db.insert
+
+      expect(postgresMock).toHaveBeenCalledTimes(1)
+      expect(drizzleMock).toHaveBeenCalledTimes(1)
+      expect(event.context.__nuxthubHyperdrivePostgresDb).toBeDefined()
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('creates a new postgres client for different request contexts', async () => {
+    // @ts-expect-error - test-only global binding
+    globalThis.__env__ = { POSTGRES: { connectionString: 'postgres://hyperdrive/different-requests' } }
+
+    const postgresMock = vi.fn((connectionString: string) => ({ connectionString }))
+    const drizzleMock = vi.fn(({ client }: { client: { connectionString: string } }) => ({
+      select: () => client.connectionString
+    }))
+    let event = { context: {} as Record<string, unknown> }
+
+    const { module, cleanup } = await importDbClientModule({
+      postgres: postgresMock,
+      drizzle: drizzleMock,
+      getEvent: () => event
+    })
+
+    try {
+      void module.db.select
+      event = { context: {} as Record<string, unknown> }
+      void module.db.select
+
+      expect(postgresMock).toHaveBeenCalledTimes(2)
+      expect(drizzleMock).toHaveBeenCalledTimes(2)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('falls back to non-cached clients when request context is unavailable', async () => {
+    // @ts-expect-error - test-only global binding
+    globalThis.__env__ = { POSTGRES: { connectionString: 'postgres://hyperdrive/no-context' } }
+
+    const postgresMock = vi.fn((connectionString: string) => ({ connectionString }))
+    const drizzleMock = vi.fn(({ client }: { client: { connectionString: string } }) => ({
+      select: () => client.connectionString
+    }))
+
+    const { module, cleanup } = await importDbClientModule({
+      postgres: postgresMock,
+      drizzle: drizzleMock
+    })
+
+    try {
+      void module.db.select
+      void module.db.select
+
+      expect(postgresMock).toHaveBeenCalledTimes(2)
+      expect(drizzleMock).toHaveBeenCalledTimes(2)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('can be loaded by Jiti without resolving Nitro runtime context', async () => {
+    const dbClient = await readFile(dbClientPath, 'utf8')
+    const tempDir = await mkdtemp(join(tmpdir(), 'nuxthub-hyperdrive-postgres-jiti-'))
+    const tempModulePath = join(tempDir, 'db.mjs')
+    const nitropackDir = join(tempDir, 'node_modules/nitropack')
+
+    const rewrittenDbClient = dbClient
+      .replace(`from 'drizzle-orm/postgres-js'`, `from './drizzle-stub.mjs'`)
+      .replace(`from 'postgres'`, `from './postgres-stub.mjs'`)
+
+    try {
+      await mkdir(nitropackDir, { recursive: true })
+      await writeFile(tempModulePath, rewrittenDbClient)
+      await writeFile(join(tempDir, 'postgres-stub.mjs'), `export default () => ({})\n`)
+      await writeFile(join(tempDir, 'drizzle-stub.mjs'), `export const drizzle = () => ({})\n`)
+      await writeFile(join(tempDir, 'schema.mjs'), `export const schemaMarker = true\n`)
+      await writeFile(join(nitropackDir, 'package.json'), JSON.stringify({
+        name: 'nitropack',
+        version: '0.0.0',
+        type: 'module',
+        exports: {
+          '.': './index.mjs'
+        }
+      }, null, 2))
+
+      const jiti = createJiti(tempModulePath, { moduleCache: false })
+
+      await expect(jiti.import(tempModulePath)).resolves.toHaveProperty('schema')
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/test/fixtures/hyperdrive-postgres/nuxt.config.ts
+++ b/test/fixtures/hyperdrive-postgres/nuxt.config.ts
@@ -2,6 +2,14 @@ import { defineNuxtConfig } from 'nuxt/config'
 
 export default defineNuxtConfig({
   modules: ['../../../src/module'],
+  nitro: {
+    preset: 'cloudflare-module',
+    cloudflare: {
+      wrangler: {
+        name: 'hub-hyperdrive-postgres-test'
+      }
+    }
+  },
   hub: {
     db: {
       dialect: 'postgresql',
@@ -11,14 +19,6 @@ export default defineNuxtConfig({
         hyperdriveId: 'test-hyperdrive-id',
         url: 'postgresql://user:pass@localhost:5432/db',
         prepare: false
-      }
-    }
-  },
-  nitro: {
-    preset: 'cloudflare-module',
-    cloudflare: {
-      wrangler: {
-        name: 'hub-hyperdrive-postgres-test'
       }
     }
   }

--- a/test/fixtures/hyperdrive-postgres/nuxt.config.ts
+++ b/test/fixtures/hyperdrive-postgres/nuxt.config.ts
@@ -1,0 +1,25 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  modules: ['../../../src/module'],
+  nitro: {
+    preset: 'cloudflare-module',
+    cloudflare: {
+      wrangler: {
+        name: 'hub-hyperdrive-postgres-test'
+      }
+    }
+  },
+  hub: {
+    db: {
+      dialect: 'postgresql',
+      driver: 'postgres-js',
+      applyMigrationsDuringBuild: false,
+      connection: {
+        hyperdriveId: 'test-hyperdrive-id',
+        url: 'postgresql://user:pass@localhost:5432/db',
+        prepare: false
+      }
+    }
+  }
+})

--- a/test/fixtures/hyperdrive-postgres/nuxt.config.ts
+++ b/test/fixtures/hyperdrive-postgres/nuxt.config.ts
@@ -1,0 +1,25 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  modules: ['../../../src/module'],
+  hub: {
+    db: {
+      dialect: 'postgresql',
+      driver: 'postgres-js',
+      applyMigrationsDuringBuild: false,
+      connection: {
+        hyperdriveId: 'test-hyperdrive-id',
+        url: 'postgresql://user:pass@localhost:5432/db',
+        prepare: false
+      }
+    }
+  },
+  nitro: {
+    preset: 'cloudflare-module',
+    cloudflare: {
+      wrangler: {
+        name: 'hub-hyperdrive-postgres-test'
+      }
+    }
+  }
+})

--- a/test/fixtures/hyperdrive-postgres/package.json
+++ b/test/fixtures/hyperdrive-postgres/package.json
@@ -1,0 +1,1 @@
+{ "private": true, "name": "hub-hyperdrive-postgres-test", "type": "module" }


### PR DESCRIPTION
## Summary
Fix the Cloudflare Hyperdrive `postgres-js` path to cache the Drizzle client per request instead of reusing a module-global client across Worker requests.

Scope is intentionally narrow:
- only the Hyperdrive `postgres-js` branch changes
- cache on `useEvent().context`
- preserve current Hyperdrive option handling
- leave other drivers and branches unchanged

## Related
- https://github.com/nuxt-modules/better-auth/pull/295#issuecomment-4228288966
- [PR #844](https://github.com/nuxt-hub/core/pull/844)
