### PR TITLE
docs: document cloudflare workers builds d1 pattern

### DIFF
--- a/docs/content/docs/1.getting-started/3.deploy.md
+++ b/docs/content/docs/1.getting-started/3.deploy.md
@@ -197,7 +197,7 @@ These environment variables are only required if you use the Nuxt DevTools for c
 If deploying to Cloudflare Workers, you can use [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) to automatically deploy your project on every commit.
 
 ::note{to="/docs/guides/ci-cd#d1-migrations-in-cicd"}
-If your project uses Cloudflare D1, add an explicit migration step before deploy. Workers Builds does not apply D1 migrations automatically.
+If your project uses Cloudflare D1, use the CI/CD guide's recommended Workers Builds pattern with migration-aware deploy commands. Workers Builds does not apply D1 migrations automatically.
 ::
 
 ## Pages CI

--- a/docs/content/docs/6.guides/3.ci-cd.md
+++ b/docs/content/docs/6.guides/3.ci-cd.md
@@ -10,13 +10,29 @@ NuxtHub applications deploy through standard CI/CD pipelines. Database migration
 
 ### Workers Builds
 
-The simplest approach is to use [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/), which automatically deploys your application on every commit.
+The recommended approach is to use [Cloudflare Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) with explicit build, deploy, and preview deploy scripts. This keeps preview and production deploys aligned while applying D1 migrations before each deployment.
 
 1. Create a Workers project in the [Cloudflare dashboard](https://dash.cloudflare.com/?to=/:account/workers-and-pages/create)
 2. Connect your GitHub or GitLab repository
-3. Configure the build settings:
-   - **Build command**: `npm run build`
-   - **Build output directory**: `dist`
+3. Add the following scripts to your `package.json`:
+
+```json [package.json]
+{
+  "scripts": {
+    "build": "bash -lc 'if [[ -z \"${WORKERS_CI_BRANCH:-}\" || \"$WORKERS_CI_BRANCH\" == \"main\" ]]; then pnpm run build:production; else pnpm run build:preview; fi'",
+    "build:production": "NODE_OPTIONS=--max-old-space-size=4096 nuxt build",
+    "build:preview": "NODE_OPTIONS=--max-old-space-size=4096 nuxt build --envName preview",
+    "deploy:cloudflare": "sh -c 'pnpm exec wrangler --cwd .output/server d1 migrations apply DB --remote && pnpm exec wrangler --cwd .output deploy --keep-vars'",
+    "deploy:cloudflare:preview": "sh -c 'pnpm exec wrangler --cwd .output/server d1 migrations apply DB --remote && pnpm exec wrangler --cwd .output versions upload'"
+  }
+}
+```
+
+4. Configure the Workers Builds settings:
+   - **Build command**: `pnpm build`
+   - **Deploy command**: `pnpm run deploy:cloudflare`
+   - **Version command**: `pnpm run deploy:cloudflare:preview`
+   - **Root directory**: `.`
 
 ::tip
 NuxtHub automatically generates wrangler bindings from your `nuxt.config.ts` during the build process. No manual `wrangler.jsonc` file is required.
@@ -30,7 +46,7 @@ If you use a custom `wrangler.jsonc` with named environments, set `CLOUDFLARE_EN
 ::
 
 ::warning{to="#d1-migrations-in-cicd"}
-If your project uses Cloudflare D1, Workers Builds still requires an explicit migration step before deploy. The default `npm run build` and `wrangler deploy` flow does not apply D1 migrations automatically.
+If your project uses Cloudflare D1, keep the migration step inside your deploy and version commands. `wrangler deploy` and Workers Builds do not apply D1 migrations automatically.
 ::
 
 ### GitHub Actions
@@ -90,11 +106,11 @@ Unlike PostgreSQL or MySQL, where build-time migrations work because the databas
 - These bindings are only available at runtime
 - CI build environments have no database connection
 
-### Solution: Pre-Deployment Migration Step
+### Solution: Migration-Aware Deploy Commands
 
-Run migrations before deployment using Wrangler or the NuxtHub CLI.
+Run migrations before deployment with Wrangler.
 
-NuxtHub generates `migrations_table` and `migrations_dir` in `.output/server/wrangler.json` for D1 projects. This enables Wrangler-managed migrations, but it does not execute them automatically during `wrangler deploy`.
+NuxtHub generates `migrations_table` and `migrations_dir` in `.output/server/wrangler.json` for D1 projects. This enables Wrangler-managed migrations, but it does not execute them automatically during `wrangler deploy`. Your deploy and preview deploy commands should run `wrangler d1 migrations apply` first, then upload or deploy the Worker.
 
 ::warning
 If you applied migrations with NuxtHub before v0.10 and you use Cloudflare D1, some rows in `_hub_migrations` may be missing the `.sql` suffix. Wrangler requires `.sql` in order to recognize the migration files.
@@ -125,13 +141,37 @@ export default defineNuxtConfig({
 })
 ```
 
-#### 2. Add the Migration Step to Your CI/CD Pipeline
+#### 2. Add the Migration Step to Your Deployment Commands
 
 **Option A: Using Wrangler (recommended)**
 
 Use Wrangler's built-in D1 migrations command. This requires your migrations to follow [Wrangler's migration format](https://developers.cloudflare.com/d1/build-with-d1/d1-migrations/).
 
-NuxtHub already generates the required metadata in `.output/server/wrangler.json`, so you can run migrations directly against the generated config:
+NuxtHub already generates the required metadata in `.output/server/wrangler.json`, so you can run migrations directly against the generated config. The following pattern works well with Workers Builds:
+
+```json [package.json]
+{
+  "scripts": {
+    "deploy:cloudflare": "sh -c 'pnpm exec wrangler --cwd .output/server d1 migrations apply DB --remote && pnpm exec wrangler --cwd .output deploy --keep-vars'",
+    "deploy:cloudflare:preview": "sh -c 'pnpm exec wrangler --cwd .output/server d1 migrations apply DB --remote && pnpm exec wrangler --cwd .output versions upload'"
+  }
+}
+```
+
+This sequence does three things:
+- It uses the generated `.output/server/wrangler.json` configuration, including `migrations_table` and `migrations_dir`
+- It applies pending D1 migrations before deployment
+- It runs the correct Cloudflare command for production traffic or preview versions
+
+After a successful deploy, verify that no migrations remain:
+
+```bash [Terminal]
+npx wrangler d1 migrations list DB --remote --config .output/server/wrangler.json
+```
+
+Wrangler should report that there are no migrations to apply.
+
+If you prefer to keep the commands in your CI workflow instead of `package.json`, use the same sequence directly:
 
 ```bash [Terminal]
 npx wrangler d1 migrations apply DB --remote --config .output/server/wrangler.json && npx wrangler deploy


### PR DESCRIPTION
This updates the Cloudflare deployment docs to recommend the validated Workers Builds pattern for D1 projects.

It documents the `pnpm build` / `pnpm run deploy:cloudflare` / `pnpm run deploy:cloudflare:preview` setup, clarifies that migrations must run inside the deploy and version commands, and links the deploy page back to the CI/CD guide for the full workflow.

Related discussion: https://github.com/nuxt/nuxt/discussions/34843

