### PR TITLE
Remove SQLite support warning for Drizzle Studio

### DIFF
--- a/docs/content/docs/2.database/1.index.md
+++ b/docs/content/docs/2.database/1.index.md
@@ -163,10 +163,6 @@ During local development, view and edit your database from [Nuxt DevTools](https
 
 :img{src="/images/landing/nuxt-devtools-database.png" alt="Nuxt DevTools Database" width="915" height="515"}
 
-::warning
-At the moment, Drizzle Studio does not support SQLite.
-::
-
 
 ## Build-time Hooks
 


### PR DESCRIPTION
Drizzle Studio in nuxt devtools does support SQLite.