### PR TITLE
fix(db): build schema with platform 'node' to silence UNRESOLVED_IMPORT warnings

### DIFF
--- a/src/db/lib/build.ts
+++ b/src/db/lib/build.ts
@@ -98,7 +98,13 @@ export async function buildDatabaseSchema(buildDir: string, { relativeDir, alias
       'hub:db:schema': entry,
       '@nuxthub/db/schema': entry
     },
-    platform: 'neutral',
+    // Node builtins bundled from the DB driver (e.g. `postgres`) are already
+    // externalized here, but under the `neutral` platform rolldown/esbuild
+    // cannot resolve them and floods dev/`db:generate` with UNRESOLVED_IMPORT
+    // warnings (os/fs/net/tls/crypto/stream/perf_hooks). The generated
+    // schema.mjs is only ever consumed by the Node server, so target `node`:
+    // builtins become silent externals with no change to runtime output.
+    platform: 'node',
     format: 'esm',
     skipNodeModulesBundle: false,
     tsconfig: false,


### PR DESCRIPTION
## Problem

`buildDatabaseSchema` (`src/db/lib/build.ts`) bundles the generated `@nuxthub/db/schema.mjs` with tsdown using `platform: 'neutral'` and `skipNodeModulesBundle: false`, which inlines the DB driver (e.g. `postgres`) into the schema bundle.

Under the **`neutral`** platform, rolldown/esbuild cannot resolve the driver's Node builtins and floods `nuxt dev` and `nuxt db generate` with `[UNRESOLVED_IMPORT]` warnings:

```
 WARN  node_modules/.pnpm/postgres@3.4.9/.../src/index.js (1:15) [UNRESOLVED_IMPORT]
   Could not resolve 'os' ... treating it as an external dependency
   Help: The "main" field here was ignored. Main fields must be configured
   explicitly when using the "neutral" platform.
```

The full set is `os`, `fs`, `net`, `tls`, `crypto`, `stream`, `perf_hooks` — reported both from the driver source **and** again from the bundled `@nuxthub/db/schema.mjs` that re-imports them. It reproduces with the `postgres-js` driver on a self-hosted (Node) setup.

## Fix

The builtins are already treated as external (`"treating it as an external dependency"`), so the warnings are pure noise. The generated schema is only consumed by the **Node** server runtime, so building it with `platform: 'node'` marks those builtins as *silent* externals. One-line change (plus an explanatory comment).

## Why not `node:`-prefix the driver imports

Doesn't help: rolldown under the `neutral` platform warns on `node:`-prefixed builtins too (`Could not resolve 'node:crypto'`), and `@nuxthub/db` is generated (not patchable).

## Verification

On a Nuxt 4.4 / Nitro 2.13 / Vite 7 project with the `postgres-js` driver:

| | before | after |
|---|---|---|
| `UNRESOLVED_IMPORT` (dev) | 15 | **0** |
| `UNRESOLVED_IMPORT` (`db:generate`) | 7+ | **0** |
| runtime `schema.mjs` exports / drizzle relations | ok | **unchanged** |
| app boots (`/` → 200) | ok | **ok** |

Runtime output of `schema.mjs` is byte-for-byte equivalent (the builtins were external before and after); only the build-time warnings disappear.