### PR TITLE
fix(blob): pass R2 jurisdiction to generated wrangler bindings (#908)

### DIFF
--- a/docs/content/docs/1.getting-started/3.deploy.md
+++ b/docs/content/docs/1.getting-started/3.deploy.md
@@ -74,6 +74,7 @@ The following table shows how NuxtHub configuration options map to Wrangler conf
 | `hub.cache.binding` | `kv_namespaces[].binding` | `CACHE` (default) |
 | `hub.blob.bucketName` | `r2_buckets[].bucket_name` | From config |
 | `hub.blob.binding` | `r2_buckets[].binding` | `BLOB` (default) |
+| `hub.blob.jurisdiction` | `r2_buckets[].jurisdiction` | From config |
 
 #### Environment Resolution
 

--- a/docs/content/docs/3.blob/1.index.md
+++ b/docs/content/docs/3.blob/1.index.md
@@ -97,7 +97,9 @@ By default, if NuxtHub cannot detect a driver, files are stored locally in the `
       hub: {
         blob: {
           driver: 'cloudflare-r2',
-          bucketName: '<bucket-name>'
+          bucketName: '<bucket-name>',
+          // Optional: for jurisdictional R2 buckets (e.g. EU)
+          // jurisdiction: 'eu'
         }
       }
     })

--- a/src/blob/setup.ts
+++ b/src/blob/setup.ts
@@ -72,13 +72,17 @@ export async function setupBlob(nuxt: Nuxt, hub: HubConfig, deps: Record<string,
   const blobConfig = hub.blob as ResolvedBlobConfig
 
   if (blobConfig.driver === 'cloudflare-r2' && blobConfig.bucketName) {
-    addWranglerBinding(nuxt, 'r2_buckets', { binding: blobConfig.binding || 'BLOB', bucket_name: blobConfig.bucketName })
+    addWranglerBinding(nuxt, 'r2_buckets', {
+      binding: blobConfig.binding || 'BLOB',
+      bucket_name: blobConfig.bucketName,
+      ...(blobConfig.jurisdiction ? { jurisdiction: blobConfig.jurisdiction } : {})
+    })
   }
 
   // Add Composables
   addImportsDir(resolve('blob/runtime/app/composables'))
 
-  const { driver, bucketName: _bucketName, ...driverOptions } = blobConfig as CloudflareR2BlobConfig
+  const { driver, bucketName: _bucketName, jurisdiction: _jurisdiction, ...driverOptions } = blobConfig as CloudflareR2BlobConfig
 
   if (!supportedDrivers.includes(driver as any)) {
     log.error(`Unsupported blob driver: ${driver}. Supported drivers: ${supportedDrivers.join(', ')}`)

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -74,7 +74,18 @@ export interface ModuleOptions {
 export type FSBlobConfig = { driver: 'fs' } & FSDriverOptions
 export type S3BlobConfig = { driver: 's3' } & S3DriverOptions
 export type VercelBlobConfig = { driver: 'vercel-blob' } & VercelDriverOptions
-export type CloudflareR2BlobConfig = { driver: 'cloudflare-r2', bucketName?: string } & CloudflareDriverOptions
+export type CloudflareR2BlobConfig = {
+  driver: 'cloudflare-r2'
+  /**
+   * R2 bucket name used to auto-generate wrangler bindings
+   */
+  bucketName?: string
+  /**
+   * R2 jurisdiction for the bucket binding (e.g. `'eu'`)
+   * @see https://developers.cloudflare.com/r2/reference/data-location/#jurisdictional-restrictions
+   */
+  jurisdiction?: string
+} & CloudflareDriverOptions
 
 export type BlobConfig = boolean | FSBlobConfig | S3BlobConfig | VercelBlobConfig | CloudflareR2BlobConfig
 export type ResolvedBlobConfig = FSBlobConfig | S3BlobConfig | VercelBlobConfig | CloudflareR2BlobConfig

--- a/test/fixtures/wrangler-jurisdiction/nuxt.config.ts
+++ b/test/fixtures/wrangler-jurisdiction/nuxt.config.ts
@@ -1,0 +1,9 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  extends: ['../basic'],
+  modules: ['../../../src/module'],
+  hub: {
+    blob: { driver: 'cloudflare-r2', bucketName: 'test-bucket', binding: 'BLOB', jurisdiction: 'eu' }
+  }
+})

--- a/test/fixtures/wrangler-jurisdiction/package.json
+++ b/test/fixtures/wrangler-jurisdiction/package.json
@@ -1,0 +1,1 @@
+{ "private": true, "name": "hub-wrangler-jurisdiction-test", "type": "module" }

--- a/test/wrangler-jurisdiction.test.ts
+++ b/test/wrangler-jurisdiction.test.ts
@@ -1,0 +1,18 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { setup, useTestContext } from '@nuxt/test-utils'
+
+describe('wrangler r2 jurisdiction e2e', async () => {
+  await setup({ rootDir: fileURLToPath(new URL('./fixtures/wrangler-jurisdiction', import.meta.url)), dev: true })
+
+  it('should include r2 jurisdiction when configured', () => {
+    const { nuxt } = useTestContext()
+    const wrangler = nuxt?.options.nitro.cloudflare?.wrangler
+
+    expect(wrangler?.r2_buckets).toContainEqual({
+      binding: 'BLOB',
+      bucket_name: 'test-bucket',
+      jurisdiction: 'eu'
+    })
+  })
+})

--- a/test/wrangler.test.ts
+++ b/test/wrangler.test.ts
@@ -24,4 +24,13 @@ describe('wrangler bindings e2e', async () => {
     expect(wrangler?.kv_namespaces).toContainEqual({ binding: 'CACHE', id: 'test-cache-id' })
     expect(wrangler?.d1_databases).toContainEqual({ binding: 'DB', database_id: 'test-db-id' })
   })
+
+  it('should omit r2 jurisdiction when not configured', () => {
+    const { nuxt } = useTestContext()
+    const wrangler = nuxt?.options.nitro.cloudflare?.wrangler
+    const blobBinding = wrangler?.r2_buckets?.find((b: { binding: string }) => b.binding === 'BLOB')
+
+    expect(blobBinding).toEqual({ binding: 'BLOB', bucket_name: 'test-bucket' })
+    expect(blobBinding).not.toHaveProperty('jurisdiction')
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #908 by passing `hub.blob.jurisdiction` through to the auto-generated Cloudflare R2 wrangler binding.

Jurisdictional R2 buckets (e.g. EU) require `jurisdiction` on the `r2_buckets` entry. NuxtHub previously only mapped `binding` and `bucket_name`, so those buckets could not be configured via `hub.blob` alone.

### Example

```ts
export default defineNuxtConfig({
  hub: {
    blob: {
      driver: 'cloudflare-r2',
      bucketName: 'my-eu-bucket',
      jurisdiction: 'eu'
    }
  }
})
```

Generates:

```json
{
  "r2_buckets": [
    {
      "binding": "BLOB",
      "bucket_name": "my-eu-bucket",
      "jurisdiction": "eu"
    }
  ]
}
```

When `jurisdiction` is omitted, the binding is unchanged (no extra field).

## Changes

- Pass optional `jurisdiction` in `src/blob/setup.ts` when generating the R2 wrangler binding
- Add `jurisdiction?: string` to `CloudflareR2BlobConfig` and exclude it from runtime driver options
- Document the option in blob and deploy docs
- Tests: omit when unset; include when set (`eu`)

## Test plan

- [X] `pnpm test test/wrangler.test.ts test/wrangler-jurisdiction.test.ts`
- [X] Configure `hub.blob` with `jurisdiction: 'eu'` and confirm `.output/server/wrangler.json` (or nitro wrangler config) includes it
- [X] Configure without `jurisdiction` and confirm the field is absent
