### PR TITLE
feat(db): support PostgreSQL migration schemas

### DIFF
--- a/cli/commands/db/mark-as-migrated.mjs
+++ b/cli/commands/db/mark-as-migrated.mjs
@@ -3,10 +3,9 @@ import { consola } from 'consola'
 import { execa } from 'execa'
 import { readFile } from 'node:fs/promises'
 import { join } from 'pathe'
-import { createDrizzleClient, getDatabaseMigrationFiles, AppliedDatabaseMigrationsQuery } from '@nuxthub/core/db'
+import { createDrizzleClient, getDatabaseMigrationFiles, getAppliedMigrationsQuery, getCreateMigrationsTableQuery, getMigrationsTableName } from '@nuxthub/core/db'
 import { sql } from 'drizzle-orm'
 import { loadDotenv, dotenvArg } from '../../utils/dotenv.mjs'
-import { quoteIdentifier } from '../../utils/db.mjs'
 
 export default defineCommand({
   meta: {
@@ -66,7 +65,9 @@ export default defineCommand({
     const execute = dialect === 'sqlite' ? 'run' : 'execute'
     const getRows = result => (dialect === 'mysql' ? result[0] : result.rows || result)
     const closeDb = async () => await db.$client?.end?.()
-    const appliedMigrations = getRows(await db[execute](sql.raw(AppliedDatabaseMigrationsQuery)))
+    if (dialect === 'postgresql')
+      await db[execute](sql.raw(getCreateMigrationsTableQuery(hubConfig.db)))
+    const appliedMigrations = getRows(await db[execute](sql.raw(getAppliedMigrationsQuery(hubConfig.db))))
     consola.info(`Database has \`${appliedMigrations.length}\` applied migration${appliedMigrations.length === 1 ? '' : 's'}`)
     consola.debug(`Applied migrations:\n${appliedMigrations.map(migration => `- ${migration.name} (\`${migration.applied_at}\`)`).join('\n')}`)
     // If a specific migration is provided, check if it is already applied
@@ -76,7 +77,7 @@ export default defineCommand({
     }
     // If a specific migration is provided, mark it as applied
     if (args.name) {
-      const migrationsTable = quoteIdentifier('_hub_migrations', dialect)
+      const migrationsTable = getMigrationsTableName(hubConfig.db)
       await db[execute](sql.raw(`INSERT INTO ${migrationsTable} (name) VALUES ('${args.name}');`))
       consola.success(`Local migration \`${args.name}\` marked as applied.`)
       return closeDb()
@@ -88,7 +89,7 @@ export default defineCommand({
       return closeDb()
     }
     consola.info(`Found \`${pendingMigrations.length}\` pending migration${pendingMigrations.length === 1 ? '' : 's'}`)
-    const migrationsTable = quoteIdentifier('_hub_migrations', dialect)
+    const migrationsTable = getMigrationsTableName(hubConfig.db)
     let migrationsMarkedAsApplied = 0
     for (const migration of pendingMigrations) {
       const confirmed = await consola.prompt(`Mark migration \`${migration.name}\` as applied?`, {

--- a/cli/commands/db/squash.mjs
+++ b/cli/commands/db/squash.mjs
@@ -3,9 +3,9 @@ import { consola } from 'consola'
 import { execa } from 'execa'
 import { readFile, writeFile, rm } from 'node:fs/promises'
 import { join, resolve } from 'pathe'
-import { buildDatabaseSchema, createDrizzleClient } from '@nuxthub/core/db'
+import { buildDatabaseSchema, createDrizzleClient, getCreateMigrationsTableQuery, getMigrationsTableName } from '@nuxthub/core/db'
 import { sql } from 'drizzle-orm'
-import { getTsconfigAliases, quoteIdentifier } from '../../utils/db.mjs'
+import { getTsconfigAliases } from '../../utils/db.mjs'
 
 export default defineCommand({
   meta: {
@@ -204,7 +204,9 @@ export default defineCommand({
         const db = await createDrizzleClient(hubConfig.db, hubDir)
         const dialect = hubConfig.db.dialect
         const execute = dialect === 'sqlite' ? 'run' : 'execute'
-        await db[execute](sql.raw(`INSERT INTO ${quoteIdentifier('_hub_migrations', dialect)} (name) VALUES ('${newMigration.tag}');`))
+        if (dialect === 'postgresql')
+          await db[execute](sql.raw(getCreateMigrationsTableQuery(hubConfig.db)))
+        await db[execute](sql.raw(`INSERT INTO ${getMigrationsTableName(hubConfig.db)} (name) VALUES ('${newMigration.tag}');`))
         await db.$client?.end?.()
         consola.success(`Migration \`${newMigration.tag}\` marked as applied.`)
       } else {

--- a/docs/content/docs/2.database/1.index.md
+++ b/docs/content/docs/2.database/1.index.md
@@ -384,6 +384,7 @@ Set these environment variables at runtime:
   | Variable | Description |
   | --- | --- |
   | `POSTGRES_URL` | Connection URL for PostgreSQL. Falls back to `POSTGRESQL_URL`, then `DATABASE_URL`. |
+  | `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSERNAME` / `PGUSER`, `PGPASSWORD` | Native Postgres.js connection settings used when no connection URL is set. |
   :::
   :::tabs-item{label="MySQL" icon="i-simple-icons-mysql"}
   | Variable | Description |

--- a/docs/content/docs/7.reference/1.environment-variables.md
+++ b/docs/content/docs/7.reference/1.environment-variables.md
@@ -15,6 +15,14 @@ NuxtHub automatically detects and configures resources based on environment vari
 | `POSTGRES_URL` | PostgreSQL connection string | 1st |
 | `POSTGRESQL_URL` | PostgreSQL connection string | 2nd |
 | `DATABASE_URL` | Generic database connection string | 3rd |
+| `PGHOST` | PostgreSQL host | Runtime fallback |
+| `PGPORT` | PostgreSQL port | Runtime fallback |
+| `PGDATABASE` | PostgreSQL database | Runtime fallback |
+| `PGUSERNAME` | PostgreSQL username | Runtime fallback |
+| `PGUSER` | PostgreSQL username | Runtime fallback |
+| `PGPASSWORD` | PostgreSQL password | Runtime fallback |
+
+The `PG*` variables are used by an explicitly configured `postgres-js` driver in non-Cloudflare production runtimes when no connection URL is set. They do not enable automatic driver detection or build and development migrations.
 
 ### MySQL
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
       "types": "./dist/db/lib/index.d.ts",
       "import": "./dist/db/lib/index.mjs"
     },
+    "./db/migrations": {
+      "types": "./dist/db/lib/migrations.d.ts",
+      "import": "./dist/db/lib/migrations.mjs"
+    },
     "./kv": {
       "types": "./dist/kv/runtime/kv.d.ts"
     }

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     }
   },
   "devDependencies": {
+    "@electric-sql/pglite": "^0.3.15",
     "@nuxt/devtools": "^3.1.1",
     "@nuxt/eslint-config": "^1.15.1",
     "@nuxt/module-builder": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
         specifier: ^4.2.1
         version: 4.3.6
     devDependencies:
+      '@electric-sql/pglite':
+        specifier: ^0.3.15
+        version: 0.3.15
       '@nuxt/devtools':
         specifier: ^3.1.1
         version: 3.2.4(@vitejs/devtools@0.1.15(@pnpm/logger@1001.0.1)(@upstash/redis@1.36.2)(@vercel/blob@2.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0)(better-sqlite3@12.6.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260214.0)(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.0)(@opentelemetry/api@1.9.0)(@upstash/redis@1.36.2)(better-sqlite3@12.6.2)(mysql2@3.17.1)(postgres@3.4.8))(mysql2@3.17.1))(ioredis@5.11.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.48.0)(yaml@2.8.2)))(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.48.0)(yaml@2.8.2))(vue@3.5.33(typescript@5.9.3))

--- a/src/db/lib/migrations.ts
+++ b/src/db/lib/migrations.ts
@@ -8,6 +8,12 @@ function getRelativePath(fullPath: string) {
   return relative(process.cwd(), fullPath)
 }
 
+function dollarQuote(value: string) {
+  let tag = '$nuxthub$'
+  while (value.includes(tag)) tag = `${tag.slice(0, -1)}_$`
+  return `${tag}${value}${tag}`
+}
+
 export async function applyDatabaseMigrations(hub: ResolvedHubConfig, db: any) {
   if (!hub.db) return
   // Create a logger for this function (at runtime so we can have the debug level when run by the CLI)
@@ -19,11 +25,19 @@ export async function applyDatabaseMigrations(hub: ResolvedHubConfig, db: any) {
   const getRows = (result: any) => (dialect === 'mysql' ? result[0] : result.results || result.rows || result) || []
 
   const createMigrationsTableQuery = getCreateMigrationsTableQuery({ dialect: hub.db.dialect })
+  const createMigrationsTableStatement = dialect === 'postgresql'
+    ? `DO ${dollarQuote(`
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('nuxthub'), hashtext('migrations'));
+  ${createMigrationsTableQuery}
+END
+`)};`
+    : createMigrationsTableQuery
   log.debug('Creating migrations table if not exists...')
   const drizzleOrmPkg = 'drizzle-orm'
   const sql = await import(drizzleOrmPkg).then(m => m.sql)
   try {
-    await db[execute](sql.raw(createMigrationsTableQuery))
+    await db[execute](sql.raw(createMigrationsTableStatement))
   } catch (error: any) {
     const message = error.cause?.message || error.message
     log.error(`Failed to create migrations table\n${message}`)
@@ -54,10 +68,19 @@ export async function applyDatabaseMigrations(hub: ResolvedHubConfig, db: any) {
   }
 
   for (const migration of pendingMigrations) {
-    let query = await migrationsStorage.getItem<string>(migration.filename)
+    const query = await migrationsStorage.getItem<string>(migration.filename)
     if (!query) continue
-    query += `\nINSERT INTO _hub_migrations (name) values ('${migration.name}');`
-    const queries = splitSqlQueries(query)
+    const queries = dialect === 'postgresql'
+      ? [`DO ${dollarQuote(`
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('nuxthub'), hashtext('migrations'));
+  IF NOT EXISTS (SELECT 1 FROM _hub_migrations WHERE name = ${dollarQuote(migration.name)}) THEN
+    EXECUTE ${dollarQuote(query)};
+    INSERT INTO _hub_migrations (name) VALUES (${dollarQuote(migration.name)});
+  END IF;
+END
+`)};`]
+      : splitSqlQueries(`${query}\nINSERT INTO _hub_migrations (name) values ('${migration.name}');`)
 
     try {
       log.debug(`Applying database migration \`${getRelativePath(join(hub.dir!, 'db/migrations', migration.filename))}\`...`)

--- a/src/db/lib/migrations.ts
+++ b/src/db/lib/migrations.ts
@@ -1,17 +1,11 @@
 import { consola } from 'consola'
 import { join, relative } from 'pathe'
 import type { ResolvedHubConfig } from '@nuxthub/core'
-import { AppliedDatabaseMigrationsQuery, getCreateMigrationsTableQuery, splitSqlQueries } from './utils'
+import { getAppliedMigrationsQuery, getCreateMigrationsTableQuery, getMigrationsTableName, dollarQuote, splitSqlQueries } from './utils'
 import { useDatabaseMigrationsStorage, getDatabaseMigrationFiles, useDatabaseQueriesStorage, getDatabaseQueryFiles } from './storage'
 
 function getRelativePath(fullPath: string) {
   return relative(process.cwd(), fullPath)
-}
-
-function dollarQuote(value: string) {
-  let tag = '$nuxthub$'
-  while (value.includes(tag)) tag = `${tag.slice(0, -1)}_$`
-  return `${tag}${value}${tag}`
 }
 
 export async function applyDatabaseMigrations(hub: ResolvedHubConfig, db: any) {
@@ -24,15 +18,8 @@ export async function applyDatabaseMigrations(hub: ResolvedHubConfig, db: any) {
   const execute = dialect === 'sqlite' ? 'run' : 'execute'
   const getRows = (result: any) => (dialect === 'mysql' ? result[0] : result.results || result.rows || result) || []
 
-  const createMigrationsTableQuery = getCreateMigrationsTableQuery({ dialect: hub.db.dialect })
-  const createMigrationsTableStatement = dialect === 'postgresql'
-    ? `DO ${dollarQuote(`
-BEGIN
-  PERFORM pg_advisory_xact_lock(hashtext('nuxthub'), hashtext('migrations'));
-  ${createMigrationsTableQuery}
-END
-`)};`
-    : createMigrationsTableQuery
+  const migrationsTable = getMigrationsTableName(hub.db)
+  const createMigrationsTableStatement = getCreateMigrationsTableQuery(hub.db)
   log.debug('Creating migrations table if not exists...')
   const drizzleOrmPkg = 'drizzle-orm'
   const sql = await import(drizzleOrmPkg).then(m => m.sql)
@@ -47,7 +34,7 @@ END
 
   let appliedRows = []
   try {
-    appliedRows = getRows(await db[execute](sql.raw(AppliedDatabaseMigrationsQuery)))
+    appliedRows = getRows(await db[execute](sql.raw(getAppliedMigrationsQuery(hub.db))))
   } catch (error: any) {
     const message = error.cause?.message || error.message
     log.error(`Failed to fetch applied migrations\n${message}`)
@@ -74,9 +61,9 @@ END
       ? [`DO ${dollarQuote(`
 BEGIN
   PERFORM pg_advisory_xact_lock(hashtext('nuxthub'), hashtext('migrations'));
-  IF NOT EXISTS (SELECT 1 FROM _hub_migrations WHERE name = ${dollarQuote(migration.name)}) THEN
+  IF NOT EXISTS (SELECT 1 FROM ${migrationsTable} WHERE name = ${dollarQuote(migration.name)}) THEN
     EXECUTE ${dollarQuote(query)};
-    INSERT INTO _hub_migrations (name) VALUES (${dollarQuote(migration.name)});
+    INSERT INTO ${migrationsTable} (name) VALUES (${dollarQuote(migration.name)});
   END IF;
 END
 `)};`]

--- a/src/db/lib/utils.ts
+++ b/src/db/lib/utils.ts
@@ -65,12 +65,45 @@ export function getMigrationMetadata(filename: string): { filename: string, name
 /**
  * Get the appropriate create table query for the migrations table based on the database dialect
  */
-export function getCreateMigrationsTableQuery(db: { dialect: string }): string {
-  const dialect = db.dialect
+type MigrationDatabaseConfig = { dialect: string, migrationsSchema?: string }
 
-  switch (dialect) {
-    case 'postgresql':
-      return CreateDatabaseMigrationsTableQueryPostgresql
+export function dollarQuote(value: string): string {
+  let tag = '$nuxthub$'
+  while (value.includes(tag)) tag = `${tag.slice(0, -1)}_$`
+  return `${tag}${value}${tag}`
+}
+
+export function getMigrationsTableName(db: MigrationDatabaseConfig): string {
+  if (db.dialect !== 'postgresql' || db.migrationsSchema === undefined) return '_hub_migrations'
+  return `"${db.migrationsSchema.replace(/"/g, '""')}"._hub_migrations`
+}
+
+export function getAppliedMigrationsQuery(db: MigrationDatabaseConfig): string {
+  return `select id, name, applied_at from ${getMigrationsTableName(db)} order by id`
+}
+
+export function getCreateMigrationsTableQuery(db: MigrationDatabaseConfig): string {
+  switch (db.dialect) {
+    case 'postgresql': {
+      const table = getMigrationsTableName(db)
+      const schema = db.migrationsSchema === undefined ? undefined : `"${db.migrationsSchema.replace(/"/g, '""')}"`
+      const relocate = schema && db.migrationsSchema !== 'public'
+        ? `
+  IF to_regclass('public._hub_migrations') IS NOT NULL AND to_regclass(${dollarQuote(table)}) IS NOT NULL THEN
+    RAISE EXCEPTION 'Migration history exists in both public and the configured schema; reconcile it before migrating';
+  END IF;
+  CREATE SCHEMA IF NOT EXISTS ${schema};
+  IF to_regclass('public._hub_migrations') IS NOT NULL THEN
+    ALTER TABLE public._hub_migrations SET SCHEMA ${schema};
+  END IF;`
+        : ''
+      return `DO ${dollarQuote(`
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('nuxthub'), hashtext('migrations'));${relocate}
+  ${CreateDatabaseMigrationsTableQueryPostgresql.replace('_hub_migrations', () => table)}
+END
+`)};`
+    }
     case 'mysql':
       return CreateDatabaseMigrationsTableQueryMysql
     case 'sqlite':

--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -592,8 +592,8 @@ export { db, schema }
       `import { drizzle } from 'drizzle-orm/postgres-js'
 ${hasReplicas ? `import { withReplicas } from 'drizzle-orm/pg-core'\n` : ''}import postgres from 'postgres'`,
       `    const url = ${urlExpr}
-    if (!url) throw new Error('DATABASE_URL, POSTGRES_URL, or POSTGRESQL_URL required')
-    const client = postgres(url, ${postgresOpts})
+    if (!url && !process.env.PGHOST && !process.env.PGPORT && !process.env.PGDATABASE && !process.env.PGUSERNAME && !process.env.PGUSER && !process.env.PGPASSWORD) throw new Error('DATABASE_URL, POSTGRES_URL, or POSTGRESQL_URL required')
+    const client = url ? postgres(url, ${postgresOpts}) : postgres(${postgresOpts})
 ${hasReplicas
   ? `    const primary = drizzle({ client, schema${casingOption} })
 

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -182,6 +182,14 @@ export type DatabaseConfig = {
    */
   migrationsDirs?: string[]
   /**
+   * PostgreSQL schema for the migration history table. Does not change application tables.
+   * When set, creates the schema and moves existing public._hub_migrations into it.
+   * If both history tables exist, migration execution stops for manual reconciliation.
+   * SQL creating this schema must use CREATE SCHEMA IF NOT EXISTS, since it exists before migrations run.
+   * Omit to keep using the connection's search_path.
+   */
+  migrationsSchema?: string
+  /**
    * The paths to the SQL queries to apply after the database migrations complete.
    */
   queriesPaths?: string[]

--- a/test/database.migrations.test.ts
+++ b/test/database.migrations.test.ts
@@ -1,0 +1,89 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'pathe'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { PGlite } from '@electric-sql/pglite'
+import { drizzle } from 'drizzle-orm/pglite'
+import type { ResolvedHubConfig } from '../src/types'
+import { applyDatabaseMigrations } from '../src/db/lib/migrations'
+
+describe('PostgreSQL migrations', () => {
+  let rootDir: string
+  let client: PGlite
+  let db: ReturnType<typeof drizzle>
+  let executedQueries: string[]
+
+  beforeEach(async () => {
+    rootDir = await mkdtemp(join(tmpdir(), 'nuxthub-postgresql-migrations-'))
+    await mkdir(join(rootDir, 'db/migrations'), { recursive: true })
+    client = new PGlite()
+    executedQueries = []
+    db = drizzle(client, {
+      logger: {
+        logQuery(query) {
+          executedQueries.push(query)
+        }
+      }
+    })
+  })
+
+  afterEach(async () => {
+    await client.close()
+    await rm(rootDir, { recursive: true, force: true })
+  })
+
+  function hub() {
+    return {
+      dir: rootDir,
+      db: { dialect: 'postgresql' }
+    } as ResolvedHubConfig
+  }
+
+  it('rolls back failed migration statements and tracking', async () => {
+    await writeFile(join(rootDir, 'db/migrations/0001_failure.postgresql.sql'), `
+      CREATE TABLE partially_applied (id integer);
+      ALTER TABLE missing_table ADD COLUMN value integer;
+    `)
+
+    expect(await applyDatabaseMigrations(hub(), db)).toBe(false)
+
+    const result = await client.query(`
+      SELECT
+        to_regclass('partially_applied') IS NOT NULL AS ddl_applied,
+        (SELECT count(*) FROM _hub_migrations) AS tracker_rows
+    `)
+    expect(result.rows).toEqual([{ ddl_applied: false, tracker_rows: 0 }])
+  })
+
+  it('serializes overlapping migration attempts and records once', async () => {
+    await writeFile(join(rootDir, 'db/migrations/0001_once.postgresql.sql'), `
+      CREATE FUNCTION migration_value() RETURNS text AS $$
+      BEGIN
+        RETURN '$nuxthub$';
+      END;
+      $$ LANGUAGE plpgsql;
+      CREATE TABLE applied_once (value text DEFAULT '$nuxthub$');
+    `)
+
+    expect(await Promise.all([
+      applyDatabaseMigrations(hub(), db),
+      applyDatabaseMigrations(hub(), db)
+    ])).toEqual([true, true])
+
+    const atomicQueries = executedQueries.filter(query => query.startsWith('DO '))
+    expect(atomicQueries).toHaveLength(4)
+    expect(atomicQueries.every((query) => {
+      const lock = query.indexOf('pg_advisory_xact_lock')
+      const guardedOperation = Math.max(query.indexOf('CREATE TABLE IF NOT EXISTS'), query.indexOf('IF NOT EXISTS (SELECT'))
+      return lock !== -1 && lock < guardedOperation
+    })).toBe(true)
+
+    const result = await client.query(`
+      SELECT
+        to_regclass('applied_once') IS NOT NULL AS ddl_applied,
+        migration_value() AS function_value,
+        (SELECT count(*) FROM _hub_migrations) AS tracker_rows
+    `)
+    expect(result.rows).toEqual([{ ddl_applied: true, function_value: '$nuxthub$', tracker_rows: 1 }])
+  })
+})

--- a/test/database.migrations.test.ts
+++ b/test/database.migrations.test.ts
@@ -6,6 +6,7 @@ import { PGlite } from '@electric-sql/pglite'
 import { drizzle } from 'drizzle-orm/pglite'
 import type { ResolvedHubConfig } from '../src/types'
 import { applyDatabaseMigrations } from '../src/db/lib/migrations'
+import { getCreateMigrationsTableQuery } from '../src/db/lib/utils'
 
 describe('PostgreSQL migrations', () => {
   let rootDir: string
@@ -32,10 +33,10 @@ describe('PostgreSQL migrations', () => {
     await rm(rootDir, { recursive: true, force: true })
   })
 
-  function hub() {
+  function hub(migrationsSchema?: string) {
     return {
       dir: rootDir,
-      db: { dialect: 'postgresql' }
+      db: { dialect: 'postgresql', migrationsSchema }
     } as ResolvedHubConfig
   }
 
@@ -85,5 +86,61 @@ describe('PostgreSQL migrations', () => {
         (SELECT count(*) FROM _hub_migrations) AS tracker_rows
     `)
     expect(result.rows).toEqual([{ ddl_applied: true, function_value: '$nuxthub$', tracker_rows: 1 }])
+  })
+
+  it('creates and reuses history alongside application tables in the configured schema', async () => {
+    await writeFile(join(rootDir, 'db/migrations/0001_auth.postgresql.sql'), `
+      CREATE SCHEMA IF NOT EXISTS auth;
+      CREATE TABLE auth.sessions (token text PRIMARY KEY);
+      INSERT INTO auth.sessions VALUES ('keep-me');
+    `)
+
+    expect(await applyDatabaseMigrations(hub('auth'), db)).toBe(true)
+    expect(await applyDatabaseMigrations(hub('auth'), db)).toBeUndefined()
+    expect((await client.query(`
+      SELECT to_regclass('public._hub_migrations') AS public_history,
+        (SELECT count(*) FROM auth._hub_migrations) AS tracker_rows,
+        (SELECT token FROM auth.sessions) AS session
+    `)).rows).toEqual([{ public_history: null, tracker_rows: 1, session: 'keep-me' }])
+  })
+
+  it('moves public history before detecting pending migrations, preserving rows and sequence', async () => {
+    await writeFile(join(rootDir, 'db/migrations/0001_auth.postgresql.sql'), `
+      CREATE SCHEMA auth;
+      CREATE TABLE auth.sessions (token text PRIMARY KEY);
+      INSERT INTO auth.sessions VALUES ('keep-me');
+    `)
+    expect(await applyDatabaseMigrations(hub(), db)).toBe(true)
+    const before = await client.query('SELECT * FROM public._hub_migrations')
+
+    expect(await applyDatabaseMigrations(hub('auth'), db)).toBeUndefined()
+    expect((await client.query('SELECT * FROM auth._hub_migrations')).rows).toEqual(before.rows)
+    expect((await client.query('SELECT * FROM auth.sessions')).rows).toEqual([{ token: 'keep-me' }])
+    expect((await client.query('SELECT to_regclass(\'public._hub_migrations\') AS old_history')).rows).toEqual([{ old_history: null }])
+    expect((await client.query('INSERT INTO auth._hub_migrations (name) VALUES (\'next\') RETURNING id')).rows).toEqual([{ id: 2 }])
+  })
+
+  it('leaves conflicting histories untouched', async () => {
+    await client.exec(getCreateMigrationsTableQuery({ dialect: 'postgresql' }))
+    await client.exec(`
+      CREATE SCHEMA auth;
+      CREATE TABLE auth._hub_migrations (LIKE public._hub_migrations INCLUDING ALL);
+      INSERT INTO public._hub_migrations (name) VALUES ('public-history');
+      INSERT INTO auth._hub_migrations (name) VALUES ('auth-history');
+    `)
+    expect(await applyDatabaseMigrations(hub('auth'), db)).toBe(false)
+    expect((await client.query('SELECT name FROM public._hub_migrations')).rows).toEqual([{ name: 'public-history' }])
+    expect((await client.query('SELECT name FROM auth._hub_migrations')).rows).toEqual([{ name: 'auth-history' }])
+  })
+
+  it('quotes custom schema names in creation, lookup, relocation and inserts', async () => {
+    const schema = `auth"quoted'. $nuxthub$ $&`
+    await writeFile(join(rootDir, 'db/migrations/0001_first.postgresql.sql'), 'CREATE TABLE first_table (id integer);')
+    expect(await applyDatabaseMigrations(hub(), db)).toBe(true)
+    await writeFile(join(rootDir, 'db/migrations/0002_second.postgresql.sql'), 'CREATE TABLE second_table (id integer);')
+    expect(await applyDatabaseMigrations(hub(schema), db)).toBe(true)
+    expect(await applyDatabaseMigrations(hub(schema), db)).toBeUndefined()
+    const table = `"${schema.replace(/"/g, '""')}"._hub_migrations`
+    expect((await client.query(`SELECT count(*) FROM ${table}`)).rows).toEqual([{ count: 2 }])
   })
 })

--- a/test/database.postgres-runtime.test.ts
+++ b/test/database.postgres-runtime.test.ts
@@ -1,0 +1,112 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest'
+import { setup } from '@nuxt/test-utils'
+
+const fixtureRoot = fileURLToPath(new URL('./fixtures/postgres-runtime', import.meta.url))
+const dbClientPath = fileURLToPath(new URL('./fixtures/postgres-runtime/node_modules/@nuxthub/db/db.mjs', import.meta.url))
+const postgresEnvVariables = ['PGHOST', 'PGPORT', 'PGDATABASE', 'PGUSERNAME', 'PGUSER', 'PGPASSWORD'] as const
+const databaseEnvVariables = ['POSTGRES_URL', 'POSTGRESQL_URL', 'DATABASE_URL', ...postgresEnvVariables] as const
+const originalEnv = { ...process.env }
+
+for (const name of databaseEnvVariables) process.env[name] = ''
+
+async function importDbClientModule(stubs: {
+  postgres: (...args: unknown[]) => unknown
+  drizzle: (...args: unknown[]) => unknown
+}) {
+  const dbClient = await readFile(dbClientPath, 'utf8')
+  const tempDir = await mkdtemp(join(tmpdir(), 'nuxthub-postgres-runtime-'))
+  const tempModulePath = join(tempDir, 'db.mjs')
+
+  const rewrittenDbClient = dbClient
+    .replace(`from 'drizzle-orm/postgres-js'`, `from './drizzle-stub.mjs'`)
+    .replace(`from 'postgres'`, `from './postgres-stub.mjs'`)
+
+  // @ts-expect-error - test-only global stub registry
+  globalThis.__nuxthubPostgresRuntimeTestStubs = stubs
+
+  await writeFile(tempModulePath, rewrittenDbClient)
+  await writeFile(join(tempDir, 'postgres-stub.mjs'), `export default (...args) => globalThis.__nuxthubPostgresRuntimeTestStubs.postgres(...args)\n`)
+  await writeFile(join(tempDir, 'drizzle-stub.mjs'), `export const drizzle = (...args) => globalThis.__nuxthubPostgresRuntimeTestStubs.drizzle(...args)\n`)
+  await writeFile(join(tempDir, 'schema.mjs'), `export const schemaMarker = true\n`)
+
+  return {
+    module: await import(`${pathToFileURL(tempModulePath).href}?t=${Date.now()}-${Math.random()}`),
+    cleanup: () => rm(tempDir, { recursive: true, force: true })
+  }
+}
+
+describe('postgres runtime client', async () => {
+  await setup({
+    rootDir: fixtureRoot,
+    dev: false
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    for (const name of databaseEnvVariables) process.env[name] = ''
+    // @ts-expect-error - test-only global cleanup
+    delete globalThis.__nuxthubPostgresRuntimeTestStubs
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it.each(postgresEnvVariables)('uses postgres options with %s', async (name) => {
+    process.env[name] = 'test-value'
+    const postgresMock = vi.fn(() => ({}))
+    const { module, cleanup } = await importDbClientModule({
+      postgres: postgresMock,
+      drizzle: vi.fn(() => ({ select: true }))
+    })
+
+    try {
+      void module.db.select
+
+      expect(postgresMock).toHaveBeenCalledOnce()
+      expect(postgresMock).toHaveBeenCalledWith(expect.objectContaining({ prepare: false }))
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('keeps connection URLs authoritative', async () => {
+    process.env.POSTGRES_URL = 'postgresql://example.test/database'
+    process.env.PGHOST = 'ignored.example.test'
+    const postgresMock = vi.fn(() => ({}))
+    const { module, cleanup } = await importDbClientModule({
+      postgres: postgresMock,
+      drizzle: vi.fn(() => ({ select: true }))
+    })
+
+    try {
+      void module.db.select
+
+      expect(postgresMock).toHaveBeenCalledWith(
+        'postgresql://example.test/database',
+        expect.objectContaining({ prepare: false })
+      )
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('retains the missing configuration error', async () => {
+    const postgresMock = vi.fn()
+    const { module, cleanup } = await importDbClientModule({
+      postgres: postgresMock,
+      drizzle: vi.fn()
+    })
+
+    try {
+      expect(() => module.db.select).toThrow('[nuxt-hub] DATABASE_URL, POSTGRES_URL, or POSTGRESQL_URL required')
+      expect(postgresMock).not.toHaveBeenCalled()
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/test/fixtures/postgres-runtime/nuxt.config.ts
+++ b/test/fixtures/postgres-runtime/nuxt.config.ts
@@ -1,0 +1,16 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  modules: ['../../../src/module'],
+  hub: {
+    db: {
+      dialect: 'postgresql',
+      driver: 'postgres-js',
+      applyMigrationsDuringBuild: false,
+      applyMigrationsDuringDev: false,
+      connection: {
+        prepare: false
+      }
+    }
+  }
+})

--- a/test/fixtures/postgres-runtime/package.json
+++ b/test/fixtures/postgres-runtime/package.json
@@ -1,0 +1,1 @@
+{ "private": true, "name": "hub-postgres-runtime-test", "type": "module" }

--- a/test/package-exports.test.ts
+++ b/test/package-exports.test.ts
@@ -1,5 +1,8 @@
-import { readFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
 import { createRequire } from 'node:module'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { execa } from 'execa'
 import { describe, expect, it } from 'vitest'
 
 describe('package exports', () => {
@@ -18,5 +21,30 @@ describe('package exports', () => {
     const resolved = require.resolve('@nuxthub/core').replace(/\\/g, '/')
 
     expect(resolved.endsWith('/dist/module.mjs')).toBe(true)
+  })
+
+  it('publishes the database migrations entrypoint', async () => {
+    const rootDir = fileURLToPath(new URL('..', import.meta.url))
+    const consumerDir = await mkdtemp(join(rootDir, '.package-exports-'))
+    const packageDir = join(consumerDir, 'node_modules/@nuxthub/core')
+    const tarballPath = join(consumerDir, 'nuxthub-core.tgz')
+
+    try {
+      await mkdir(packageDir, { recursive: true })
+      await execa('pnpm', ['--config.ignore-scripts=true', 'pack', '--out', tarballPath], { cwd: rootDir })
+      await execa('tar', ['-xzf', tarballPath, '--strip-components=1', '-C', packageDir])
+
+      const { stdout } = await execa(process.execPath, [
+        '--input-type=module',
+        '--eval',
+        `const migrations = await import('@nuxthub/core/db/migrations')
+if (typeof migrations.applyDatabaseMigrations !== 'function' || typeof migrations.applyDatabaseQueries !== 'function') process.exit(1)
+console.log('ok')`
+      ], { cwd: consumerDir })
+
+      expect(stdout).toBe('ok')
+    } finally {
+      await rm(consumerDir, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
Allow PostgreSQL migration history to live alongside application tables, with atomic migration execution.

```ts
hub: {
  db: {
    dialect: 'postgresql',
    migrationsSchema: 'auth'
  }
}
```

```text
prepare history under advisory lock
  move public._hub_migrations into the configured schema
apply each pending migration under the same lock
  recheck history → run SQL + record migration atomically
```

The runner and CLI use the configured history table. Existing rows survive relocation; if both history tables exist, execution stops for manual reconciliation. Omitting `migrationsSchema` keeps the existing search-path behavior. Application tables keep the schemas declared in Drizzle.

This branch also includes the PostgreSQL runtime environment-variable support from #923, allowing deployments to use `PG*` variables without a connection URL.

### Compatibility

- The configured schema exists before migrations run. SQL that creates it must use `CREATE SCHEMA IF NOT EXISTS`.
- Stop old runners before relocating history. Move history back before restarting old code during rollback.
- PostgreSQL migrations run in one transaction and require PL/pgSQL. Commands such as `CREATE INDEX CONCURRENTLY` cannot run in this transaction.
- Other dialects retain their existing behavior. Neon HTTP has not been verified against a live endpoint.
