### PR TITLE
fix(db): skip dts generation when TypeScript 7 is resolved

### DIFF
--- a/src/db/lib/build.ts
+++ b/src/db/lib/build.ts
@@ -5,9 +5,12 @@ import type { ResolvedHubConfig } from '@nuxthub/core'
 import { consola } from 'consola'
 import { createDrizzleClient } from './client'
 import { applyDatabaseMigrations, applyDatabaseQueries } from './migrations'
+import { resolveTypescriptVersion, supportsDtsGeneration } from './ts-version'
 import { build } from 'tsdown'
 
 const log = consola.withTag('nuxt:hub')
+
+const generateDts = supportsDtsGeneration(resolveTypescriptVersion())
 
 /**
  * Copies database migrations and queries to the build output directory
@@ -108,11 +111,13 @@ export async function buildDatabaseSchema(buildDir: string, { relativeDir, alias
     format: 'esm',
     skipNodeModulesBundle: false,
     tsconfig: false,
-    dts: {
-      build: false,
-      tsconfig: false,
-      newContext: true
-    },
+    dts: generateDts
+      ? {
+          build: false,
+          tsconfig: false,
+          newContext: true
+        }
+      : false,
     clean: false,
     logLevel: 'warn'
   })

--- a/src/db/lib/ts-version.ts
+++ b/src/db/lib/ts-version.ts
@@ -1,0 +1,26 @@
+import { createRequire } from 'node:module'
+
+/**
+ * Resolves the TypeScript version used by the project, if any.
+ * Returns `undefined` when TypeScript cannot be resolved (it is an optional
+ * dependency of `tsdown`, so this is a valid state).
+ */
+export function resolveTypescriptVersion() {
+  try {
+    return createRequire(import.meta.url)('typescript/package.json').version
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * TypeScript 7 (the native port) does not ship the JS compiler API used by
+ * `rolldown-plugin-dts` to emit `.d.ts` files, so tsdown's `dts` option crashes
+ * with `Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')`.
+ * The generated `schema.d.mts` is only used as a typing hint for `hub:db:schema`
+ * and falls back to `export * from './schema.mjs'` when missing, so skip it
+ * entirely when TypeScript 7 is resolved.
+ */
+export function supportsDtsGeneration(typescriptVersion?: string) {
+  return !typescriptVersion || Number.parseInt(typescriptVersion.split('.')[0], 10) < 7
+}

--- a/test/database.schema-build.test.ts
+++ b/test/database.schema-build.test.ts
@@ -4,6 +4,7 @@ import { dirname, join, relative } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { buildDatabaseSchema } from '../src/db/lib/build'
+import { supportsDtsGeneration } from '../src/db/lib/ts-version'
 
 function toImportSpecifier(fromFile: string, toFile: string) {
   const relativePath = relative(dirname(fromFile), toFile).replace(/\\/g, '/')
@@ -68,5 +69,16 @@ describe('buildDatabaseSchema', () => {
     } finally {
       await rm(rootDir, { recursive: true, force: true })
     }
+  })
+
+  it('skips dts generation when TypeScript 7 is resolved', () => {
+    // The native TypeScript port has no JS compiler API, so `rolldown-plugin-dts`
+    // crashes while emitting `.d.ts` files. `.d.mts` types are optional anyway:
+    // `hub:db:schema` falls back to `export * from './schema.mjs'` when missing.
+    expect(supportsDtsGeneration('7.0.2')).toBe(false)
+    expect(supportsDtsGeneration('7.0.0-dev.20251223.1')).toBe(false)
+    expect(supportsDtsGeneration('6.0.0')).toBe(true)
+    expect(supportsDtsGeneration('5.9.3')).toBe(true)
+    expect(supportsDtsGeneration(undefined)).toBe(true)
   })
 })


### PR DESCRIPTION
## Problem

`nuxt prepare` / `nuxt build` / `nuxt db generate` crash with `Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')` when the project resolves **TypeScript 7** (the native Go port).

`buildDatabaseSchema` passes `dts: { build: false, tsconfig: false, newContext: true }` to `tsdown`. That enables `rolldown-plugin-dts`, which at import time calls `ts.sys.useCaseSensitiveFileNames`. TypeScript 7.0 does not ship the JS compiler API (`ts.sys`, `ts.createProgram`, …), so the plugin throws before any `.d.mts` is generated. See the local patch in [personal-website](https://github.com/BobbyLin23/personal-website/blob/master/patches/@nuxthub__core@0.10.8.patch) that works around this by always disabling `dts`.

## Fix

Detect the resolved TypeScript version and pass `dts: false` when it is 7+, keeping `.d.mts` generation for TypeScript 5/6 and for projects without TypeScript installed (both are valid states, since `typescript` is an optional peer dependency of `tsdown`).

Disabling `.d.mts` generation on TS7 is safe: the module already falls back to `export * from './schema.mjs'` for the `hub:db:schema` typing when `schema.d.mts` is missing (see `schemaTypes` handling in `module.ts`), and the schema build tests assert on `.mjs` output only.

## Verification

- `pnpm test` — 116 passed, 3 skipped (includes a new regression test for the version predicate, covering `7.0.0-dev.*` prereleases, TS 5/6 and no-TypeScript cases).
- `pnpm lint` on changed files passes.
- Reproduced the crash with the current `tsdown@0.18.4` + `typescript@7.0.2` combo, then confirmed the patched build produces `schema.mjs` and runs `nuxt prepare`, `nuxt build` and the full E2E suite successfully in the affected project.