### PR TITLE
fix(db): support PostgreSQL environment variables at runtime

### DIFF
--- a/docs/content/docs/2.database/1.index.md
+++ b/docs/content/docs/2.database/1.index.md
@@ -384,6 +384,7 @@ Set these environment variables at runtime:
   | Variable | Description |
   | --- | --- |
   | `POSTGRES_URL` | Connection URL for PostgreSQL. Falls back to `POSTGRESQL_URL`, then `DATABASE_URL`. |
+  | `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSERNAME` / `PGUSER`, `PGPASSWORD` | Native Postgres.js connection settings used when no connection URL is set. |
   :::
   :::tabs-item{label="MySQL" icon="i-simple-icons-mysql"}
   | Variable | Description |

--- a/docs/content/docs/7.reference/1.environment-variables.md
+++ b/docs/content/docs/7.reference/1.environment-variables.md
@@ -15,6 +15,14 @@ NuxtHub automatically detects and configures resources based on environment vari
 | `POSTGRES_URL` | PostgreSQL connection string | 1st |
 | `POSTGRESQL_URL` | PostgreSQL connection string | 2nd |
 | `DATABASE_URL` | Generic database connection string | 3rd |
+| `PGHOST` | PostgreSQL host | Runtime fallback |
+| `PGPORT` | PostgreSQL port | Runtime fallback |
+| `PGDATABASE` | PostgreSQL database | Runtime fallback |
+| `PGUSERNAME` | PostgreSQL username | Runtime fallback |
+| `PGUSER` | PostgreSQL username | Runtime fallback |
+| `PGPASSWORD` | PostgreSQL password | Runtime fallback |
+
+The `PG*` variables are used by an explicitly configured `postgres-js` driver in non-Cloudflare production runtimes when no connection URL is set. They do not enable automatic driver detection or build and development migrations.
 
 ### MySQL
 

--- a/src/db/setup.ts
+++ b/src/db/setup.ts
@@ -592,8 +592,8 @@ export { db, schema }
       `import { drizzle } from 'drizzle-orm/postgres-js'
 ${hasReplicas ? `import { withReplicas } from 'drizzle-orm/pg-core'\n` : ''}import postgres from 'postgres'`,
       `    const url = ${urlExpr}
-    if (!url) throw new Error('DATABASE_URL, POSTGRES_URL, or POSTGRESQL_URL required')
-    const client = postgres(url, ${postgresOpts})
+    if (!url && !process.env.PGHOST && !process.env.PGPORT && !process.env.PGDATABASE && !process.env.PGUSERNAME && !process.env.PGUSER && !process.env.PGPASSWORD) throw new Error('DATABASE_URL, POSTGRES_URL, or POSTGRESQL_URL required')
+    const client = url ? postgres(url, ${postgresOpts}) : postgres(${postgresOpts})
 ${hasReplicas
   ? `    const primary = drizzle({ client, schema${casingOption} })
 

--- a/test/database.postgres-runtime.test.ts
+++ b/test/database.postgres-runtime.test.ts
@@ -1,0 +1,112 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest'
+import { setup } from '@nuxt/test-utils'
+
+const fixtureRoot = fileURLToPath(new URL('./fixtures/postgres-runtime', import.meta.url))
+const dbClientPath = fileURLToPath(new URL('./fixtures/postgres-runtime/node_modules/@nuxthub/db/db.mjs', import.meta.url))
+const postgresEnvVariables = ['PGHOST', 'PGPORT', 'PGDATABASE', 'PGUSERNAME', 'PGUSER', 'PGPASSWORD'] as const
+const databaseEnvVariables = ['POSTGRES_URL', 'POSTGRESQL_URL', 'DATABASE_URL', ...postgresEnvVariables] as const
+const originalEnv = { ...process.env }
+
+for (const name of databaseEnvVariables) process.env[name] = ''
+
+async function importDbClientModule(stubs: {
+  postgres: (...args: unknown[]) => unknown
+  drizzle: (...args: unknown[]) => unknown
+}) {
+  const dbClient = await readFile(dbClientPath, 'utf8')
+  const tempDir = await mkdtemp(join(tmpdir(), 'nuxthub-postgres-runtime-'))
+  const tempModulePath = join(tempDir, 'db.mjs')
+
+  const rewrittenDbClient = dbClient
+    .replace(`from 'drizzle-orm/postgres-js'`, `from './drizzle-stub.mjs'`)
+    .replace(`from 'postgres'`, `from './postgres-stub.mjs'`)
+
+  // @ts-expect-error - test-only global stub registry
+  globalThis.__nuxthubPostgresRuntimeTestStubs = stubs
+
+  await writeFile(tempModulePath, rewrittenDbClient)
+  await writeFile(join(tempDir, 'postgres-stub.mjs'), `export default (...args) => globalThis.__nuxthubPostgresRuntimeTestStubs.postgres(...args)\n`)
+  await writeFile(join(tempDir, 'drizzle-stub.mjs'), `export const drizzle = (...args) => globalThis.__nuxthubPostgresRuntimeTestStubs.drizzle(...args)\n`)
+  await writeFile(join(tempDir, 'schema.mjs'), `export const schemaMarker = true\n`)
+
+  return {
+    module: await import(`${pathToFileURL(tempModulePath).href}?t=${Date.now()}-${Math.random()}`),
+    cleanup: () => rm(tempDir, { recursive: true, force: true })
+  }
+}
+
+describe('postgres runtime client', async () => {
+  await setup({
+    rootDir: fixtureRoot,
+    dev: false
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    for (const name of databaseEnvVariables) process.env[name] = ''
+    // @ts-expect-error - test-only global cleanup
+    delete globalThis.__nuxthubPostgresRuntimeTestStubs
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it.each(postgresEnvVariables)('uses postgres options with %s', async (name) => {
+    process.env[name] = 'test-value'
+    const postgresMock = vi.fn(() => ({}))
+    const { module, cleanup } = await importDbClientModule({
+      postgres: postgresMock,
+      drizzle: vi.fn(() => ({ select: true }))
+    })
+
+    try {
+      void module.db.select
+
+      expect(postgresMock).toHaveBeenCalledOnce()
+      expect(postgresMock).toHaveBeenCalledWith(expect.objectContaining({ prepare: false }))
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('keeps connection URLs authoritative', async () => {
+    process.env.POSTGRES_URL = 'postgresql://example.test/database'
+    process.env.PGHOST = 'ignored.example.test'
+    const postgresMock = vi.fn(() => ({}))
+    const { module, cleanup } = await importDbClientModule({
+      postgres: postgresMock,
+      drizzle: vi.fn(() => ({ select: true }))
+    })
+
+    try {
+      void module.db.select
+
+      expect(postgresMock).toHaveBeenCalledWith(
+        'postgresql://example.test/database',
+        expect.objectContaining({ prepare: false })
+      )
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('retains the missing configuration error', async () => {
+    const postgresMock = vi.fn()
+    const { module, cleanup } = await importDbClientModule({
+      postgres: postgresMock,
+      drizzle: vi.fn()
+    })
+
+    try {
+      expect(() => module.db.select).toThrow('[nuxt-hub] DATABASE_URL, POSTGRES_URL, or POSTGRESQL_URL required')
+      expect(postgresMock).not.toHaveBeenCalled()
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/test/fixtures/postgres-runtime/nuxt.config.ts
+++ b/test/fixtures/postgres-runtime/nuxt.config.ts
@@ -1,0 +1,16 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  modules: ['../../../src/module'],
+  hub: {
+    db: {
+      dialect: 'postgresql',
+      driver: 'postgres-js',
+      applyMigrationsDuringBuild: false,
+      applyMigrationsDuringDev: false,
+      connection: {
+        prepare: false
+      }
+    }
+  }
+})

--- a/test/fixtures/postgres-runtime/package.json
+++ b/test/fixtures/postgres-runtime/package.json
@@ -1,0 +1,1 @@
+{ "private": true, "name": "hub-postgres-runtime-test", "type": "module" }


### PR DESCRIPTION
NuxtHub's generated non-Cloudflare `postgres-js` client currently rejects runtime configuration unless a connection URL is available. That prevents Postgres.js from applying its native `PG*` environment fallback and forces container deployments to serialize discrete credentials into a URL.

This keeps the existing URL priority unchanged. When no URL is available but `PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSERNAME` / `PGUSER`, or `PGPASSWORD` is set, the generated client now invokes Postgres.js with the configured options and lets the driver resolve its environment. With neither input form, the existing NuxtHub configuration error remains.

The change is limited to the explicit non-Cloudflare production `postgres-js` runtime. Driver detection, build and development migrations, Cloudflare, Neon, and replica configuration are unchanged.
