### PR TITLE
fix(blob): avoid generic multipart requests for Vercel Blob

### DIFF
--- a/src/blob/runtime/app/composables/useMultipartUpload.ts
+++ b/src/blob/runtime/app/composables/useMultipartUpload.ts
@@ -76,12 +76,43 @@ export function useMultipartUpload(
   }
 
   return (file) => {
+    const progress = ref(0)
+    const hub = useRuntimeConfig().public.hub
+
+    if (hub.blobProvider === 'vercel-blob') {
+      const controller = new AbortController()
+      const pathname = prefix
+        ? joinURL(prefix, file.name)
+        : file.name
+
+      const completed = (async () => {
+        const { upload } = await import('@vercel/blob/client')
+
+        return upload(pathname, file, {
+          access: 'public',
+          multipart: true,
+          handleUploadUrl: joinURL(baseURL, 'multipart', pathname),
+          abortSignal: controller.signal,
+          onUploadProgress: (uploadProgress) => {
+            progress.value = uploadProgress.percentage
+          }
+        })
+      })()
+
+      return {
+        completed,
+        progress: readonly(progress),
+        abort: async () => {
+          controller.abort()
+        }
+      }
+    }
+
     const data = create(file)
     const chunks = Math.ceil(file.size / partSize)
 
     const queue = Array.from({ length: chunks }, (_, i) => i + 1)
     const parts: Awaited<ReturnType<typeof upload>>[] = []
-    const progress = ref(0)
     const errors: Error[] = []
     let canceled = false
 
@@ -128,19 +159,6 @@ export function useMultipartUpload(
     }
 
     const start = async () => {
-      const hub = useRuntimeConfig().public.hub
-      if (hub.blobProvider === 'vercel-blob') {
-        const { upload } = await import('@vercel/blob/client')
-        return upload(file.name, file, {
-          access: 'public',
-          multipart: true,
-          handleUploadUrl: joinURL(baseURL, 'multipart', file.name || ''),
-          onUploadProgress: (uploadProgress) => {
-            progress.value = uploadProgress.percentage
-          }
-        })
-      }
-
       try {
         await Promise.all(Array.from({ length: concurrent }).map(() => {
           const partNumber = queue.shift()

--- a/test/blob.multipart.test.ts
+++ b/test/blob.multipart.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useMultipartUpload } from '../src/blob/runtime/app/composables/useMultipartUpload'
+
+const mocks = vi.hoisted(() => ({
+  blobProvider: 'vercel-blob',
+  fetch: vi.fn(),
+  vercelUpload: vi.fn()
+}))
+
+vi.mock('#imports', () => ({
+  useRuntimeConfig: () => ({
+    public: {
+      hub: {
+        blobProvider: mocks.blobProvider
+      }
+    }
+  })
+}))
+
+vi.mock('ofetch', () => ({
+  ofetch: {
+    create: () => mocks.fetch
+  }
+}))
+
+vi.mock('@vercel/blob/client', () => ({
+  upload: mocks.vercelUpload
+}))
+
+describe('useMultipartUpload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.blobProvider = 'vercel-blob'
+    mocks.vercelUpload.mockResolvedValue({
+      pathname: 'test.txt',
+      contentType: 'text/plain',
+      size: 4,
+      url: 'https://example.com/test.txt'
+    })
+  })
+
+  it('does not create a generic multipart upload for Vercel Blob', async () => {
+    const file = new File(['test'], 'test.txt', { type: 'text/plain' })
+    const upload = useMultipartUpload('/api/blob/multipart')
+
+    await upload(file).completed
+
+    expect(mocks.fetch).not.toHaveBeenCalled()
+    expect(mocks.vercelUpload).toHaveBeenCalledOnce()
+  })
+
+  it('uses prefix for Vercel Blob pathname and handleUploadUrl', async () => {
+    const file = new File(['test'], 'test.txt', { type: 'text/plain' })
+    const upload = useMultipartUpload('/api/blob/multipart', {
+      prefix: 'uploads/documents'
+    })
+
+    await upload(file).completed
+
+    expect(mocks.vercelUpload).toHaveBeenCalledWith(
+      'uploads/documents/test.txt',
+      file,
+      expect.objectContaining({
+        access: 'public',
+        multipart: true,
+        handleUploadUrl: '/api/blob/multipart/multipart/uploads/documents/test.txt'
+      })
+    )
+  })
+
+  it('aborts Vercel Blob upload using AbortSignal', async () => {
+    const file = new File(['test'], 'test.txt', { type: 'text/plain' })
+    const upload = useMultipartUpload('/api/blob/multipart')
+    const uploader = upload(file)
+
+    await vi.waitFor(() => {
+      expect(mocks.vercelUpload).toHaveBeenCalledOnce()
+    })
+
+    const options = mocks.vercelUpload.mock.calls[0]![2]
+
+    expect(options.abortSignal.aborted).toBe(false)
+
+    await uploader.abort()
+
+    expect(options.abortSignal.aborted).toBe(true)
+  })
+
+  it('updates progress from Vercel Blob upload progress', async () => {
+    mocks.vercelUpload.mockImplementation(async (_pathname, _file, options) => {
+      options.onUploadProgress({ percentage: 42 })
+
+      return {
+        pathname: 'test.txt',
+        contentType: 'text/plain',
+        size: 4,
+        url: 'https://example.com/test.txt'
+      }
+    })
+
+    const file = new File(['test'], 'test.txt', { type: 'text/plain' })
+    const upload = useMultipartUpload('/api/blob/multipart')
+    const uploader = upload(file)
+
+    await uploader.completed
+
+    expect(uploader.progress.value).toBe(42)
+  })
+
+  it('keeps using the generic multipart flow for other providers', async () => {
+    mocks.blobProvider = 'fs'
+
+    mocks.fetch.mockImplementation(async (path: string) => {
+      if (path.startsWith('/create/')) {
+        return {
+          pathname: 'test.txt',
+          uploadId: 'upload-id'
+        }
+      }
+
+      if (path.startsWith('/upload/')) {
+        return {
+          partNumber: 1,
+          etag: 'etag'
+        }
+      }
+
+      if (path.startsWith('/complete/')) {
+        return {
+          pathname: 'test.txt',
+          contentType: 'text/plain',
+          size: 4
+        }
+      }
+    })
+
+    const file = new File(['test'], 'test.txt', { type: 'text/plain' })
+    const upload = useMultipartUpload('/api/blob/multipart', {
+      partSize: 10
+    })
+
+    await upload(file).completed
+
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      '/create/test.txt',
+      expect.objectContaining({
+        method: 'POST'
+      })
+    )
+    expect(mocks.vercelUpload).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Fix Vercel Blob multipart uploads to avoid triggering the generic multipart flow.

Previously, `useMultipartUpload()` called `create(file)` before checking the configured blob provider. As a result, Vercel Blob uploads triggered an unnecessary `/create/...` request before starting the actual Vercel multipart upload.

This PR:

* avoids generic multipart requests for `vercel-blob`
* uses `AbortController` for Vercel uploads
* respects the configured `prefix` for Vercel Blob pathnames
* keeps the existing multipart flow unchanged for FS/S3/R2
* adds regression tests for the Vercel multipart flow

## Tests

Added coverage for:

* no generic `create` request on Vercel Blob
* prefixed Vercel Blob pathnames and `handleUploadUrl`
* aborting Vercel uploads through `AbortSignal`
* upload progress updates
* unchanged generic multipart behavior for other providers
